### PR TITLE
Enable Price Sets select when CiviCRM taxes not defined

### DIFF
--- a/includes/classes/class-woo-civi-helper.php
+++ b/includes/classes/class-woo-civi-helper.php
@@ -421,13 +421,8 @@ class WPCV_Woo_Civi_Helper {
 			return false;
 		}
 
-		// Get the CiviCRM Tax Rates.
+		// Get the CiviCRM Tax Rates and "Tax Enabled" status.
 		$tax_rates = WPCV_WCI()->tax->rates_get();
-		if ( empty( $tax_rates ) ) {
-			return false;
-		}
-
-		// Get "Tax Enabled" status.
 		$tax_enabled = WPCV_WCI()->tax->is_tax_enabled();
 
 		$price_sets_data = [];
@@ -456,8 +451,8 @@ class WPCV_Woo_Civi_Helper {
 					}
 
 					// Add Tax data if necessary.
-					if ( $tax_enabled && $tax_rates && array_key_exists( $price_field_value['financial_type_id'], $tax_rates ) ) {
-						$price_field_value['tax_rate'] = $tax_rates[$price_field_value['financial_type_id']];
+					if ( $tax_enabled && empty( $tax_rates ) && array_key_exists( $price_field_value['financial_type_id'], $tax_rates ) ) {
+						$price_field_value['tax_rate'] = $tax_rates[ $price_field_value['financial_type_id'] ];
 						$price_field_value['tax_amount'] = $this->percentage( $price_field_value['amount'], $price_field_value['tax_rate'] );
 					}
 

--- a/includes/classes/class-woo-civi-products-custom.php
+++ b/includes/classes/class-woo-civi-products-custom.php
@@ -162,9 +162,7 @@ class WPCV_Woo_Civi_Products_Custom {
 
 		// Ensure Custom Product Types have "Add to Cart" button.
 		foreach ( $this->product_names as $type => $name ) {
-			add_action( "woocommerce_{$type}_add_to_cart", function() {
-				do_action( 'woocommerce_simple_add_to_cart' );
-			} );
+			add_action( "woocommerce_{$type}_add_to_cart", [ $this, 'buttons_add' ] );
 		}
 
 	}
@@ -450,6 +448,17 @@ class WPCV_Woo_Civi_Products_Custom {
 			}
 		}
 
+	}
+
+	/**
+	 * Adds the "Add to cart" button to our Custom Product Type Product pages.
+	 *
+	 * @see woocommerce_template_single_add_to_cart()
+	 *
+	 * @since 3.0
+	 */
+	public function buttons_add() {
+		do_action( 'woocommerce_simple_add_to_cart' );
 	}
 
 	/**

--- a/includes/classes/class-woo-civi-products-custom.php
+++ b/includes/classes/class-woo-civi-products-custom.php
@@ -160,6 +160,13 @@ class WPCV_Woo_Civi_Products_Custom {
 		// Get the Price Field Value ID from WooCommerce Product meta.
 		add_filter( 'wpcv_woo_civi/product/query/pfv_id', [ $this, 'pfv_id_get' ], 20, 2 );
 
+		// Ensure Custom Product Types have "Add to Cart" button.
+		foreach ( $this->product_names as $type => $name ) {
+			add_action( "woocommerce_{$type}_add_to_cart", function() {
+				do_action( 'woocommerce_simple_add_to_cart' );
+			} );
+		}
+
 	}
 
 	/**


### PR DESCRIPTION
Latest commits will show the Price Field Value select regardless of whether tax rates are set in CiviCRM.