### PR TITLE
First pass at support for Variable Products

### DIFF
--- a/assets/css/pages/page-admin.css
+++ b/assets/css/pages/page-admin.css
@@ -1,0 +1,1079 @@
+/**
+ * Admin page styles.
+ *
+ * Implements styling for the Admin page.
+ *
+ * @package WPCV_Woo_Civi
+ */
+
+
+
+/* "Events to Participant Products" setup.
+----------------------------------*/
+#wpcv_woocivi_info h4 {
+    font-size: 1.1em;
+}
+
+#wpcv_woocivi_info p, #wpcv_woo_civi_info ul li {
+    font-size: 14px;
+}
+
+#wpcv_woocivi_info code {
+    font-size: 13px;
+}
+
+#wpcv_woocivi_info ul {
+	list-style: disc;
+	padding-left: 20px;
+}
+
+#wpcv_woocivi_info #event-progress-bar {
+	display: none;
+}
+
+body.js #wpcv_woocivi_info #wpcv_woocivi_event_process_stop {
+	display: none;
+}
+
+
+
+/*! jQuery UI - v1.11.4 - 2016-03-30
+* http://jqueryui.com
+* Includes: core.css, progressbar.css, theme.css
+* To view and modify this theme, visit http://jqueryui.com/themeroller/?ffDefault=Verdana%2CArial%2Csans-serif&fwDefault=normal&fsDefault=1.1em&cornerRadius=4px&bgColorHeader=cccccc&bgTextureHeader=highlight_soft&bgImgOpacityHeader=75&borderColorHeader=aaaaaa&fcHeader=222222&iconColorHeader=222222&bgColorContent=ffffff&bgTextureContent=flat&bgImgOpacityContent=75&borderColorContent=aaaaaa&fcContent=222222&iconColorContent=222222&bgColorDefault=e6e6e6&bgTextureDefault=glass&bgImgOpacityDefault=75&borderColorDefault=d3d3d3&fcDefault=555555&iconColorDefault=888888&bgColorHover=dadada&bgTextureHover=glass&bgImgOpacityHover=75&borderColorHover=999999&fcHover=212121&iconColorHover=454545&bgColorActive=ffffff&bgTextureActive=glass&bgImgOpacityActive=65&borderColorActive=aaaaaa&fcActive=212121&iconColorActive=454545&bgColorHighlight=fbf9ee&bgTextureHighlight=glass&bgImgOpacityHighlight=55&borderColorHighlight=fcefa1&fcHighlight=363636&iconColorHighlight=2e83ff&bgColorError=fef1ec&bgTextureError=glass&bgImgOpacityError=95&borderColorError=cd0a0a&fcError=cd0a0a&iconColorError=cd0a0a&bgColorOverlay=aaaaaa&bgTextureOverlay=flat&bgImgOpacityOverlay=0&opacityOverlay=30&bgColorShadow=aaaaaa&bgTextureShadow=flat&bgImgOpacityShadow=0&opacityShadow=30&thicknessShadow=8px&offsetTopShadow=-8px&offsetLeftShadow=-8px&cornerRadiusShadow=8px
+* Copyright jQuery Foundation and other contributors; Licensed MIT */
+
+/* Layout helpers
+----------------------------------*/
+.ui-helper-hidden {
+	display: none;
+}
+.ui-helper-hidden-accessible {
+	border: 0;
+	clip: rect(0 0 0 0);
+	height: 1px;
+	margin: -1px;
+	overflow: hidden;
+	padding: 0;
+	position: absolute;
+	width: 1px;
+}
+.ui-helper-reset {
+	margin: 0;
+	padding: 0;
+	border: 0;
+	outline: 0;
+	line-height: 1.3;
+	text-decoration: none;
+	font-size: 100%;
+	list-style: none;
+}
+.ui-helper-clearfix:before,
+.ui-helper-clearfix:after {
+	content: "";
+	display: table;
+	border-collapse: collapse;
+}
+.ui-helper-clearfix:after {
+	clear: both;
+}
+.ui-helper-clearfix {
+	min-height: 0; /* support: IE7 */
+}
+.ui-helper-zfix {
+	width: 100%;
+	height: 100%;
+	top: 0;
+	left: 0;
+	position: absolute;
+	opacity: 0;
+	filter:Alpha(Opacity=0); /* support: IE8 */
+}
+
+.ui-front {
+	z-index: 100;
+}
+
+
+/* Interaction Cues
+----------------------------------*/
+.ui-state-disabled {
+	cursor: default !important;
+}
+
+
+/* Icons
+----------------------------------*/
+
+/* states and images */
+.ui-icon {
+	display: block;
+	text-indent: -99999px;
+	overflow: hidden;
+	background-repeat: no-repeat;
+}
+
+
+/* Misc visuals
+----------------------------------*/
+
+/* Overlays */
+.ui-widget-overlay {
+	position: fixed;
+	top: 0;
+	left: 0;
+	width: 100%;
+	height: 100%;
+}
+.ui-progressbar {
+	height: 2em;
+	text-align: left;
+	overflow: hidden;
+}
+.ui-progressbar .ui-progressbar-value {
+	margin: -1px;
+	height: 100%;
+}
+.ui-progressbar .ui-progressbar-overlay {
+	background: url("data:image/gif;base64,R0lGODlhKAAoAIABAAAAAP///yH/C05FVFNDQVBFMi4wAwEAAAAh+QQJAQABACwAAAAAKAAoAAACkYwNqXrdC52DS06a7MFZI+4FHBCKoDeWKXqymPqGqxvJrXZbMx7Ttc+w9XgU2FB3lOyQRWET2IFGiU9m1frDVpxZZc6bfHwv4c1YXP6k1Vdy292Fb6UkuvFtXpvWSzA+HycXJHUXiGYIiMg2R6W459gnWGfHNdjIqDWVqemH2ekpObkpOlppWUqZiqr6edqqWQAAIfkECQEAAQAsAAAAACgAKAAAApSMgZnGfaqcg1E2uuzDmmHUBR8Qil95hiPKqWn3aqtLsS18y7G1SzNeowWBENtQd+T1JktP05nzPTdJZlR6vUxNWWjV+vUWhWNkWFwxl9VpZRedYcflIOLafaa28XdsH/ynlcc1uPVDZxQIR0K25+cICCmoqCe5mGhZOfeYSUh5yJcJyrkZWWpaR8doJ2o4NYq62lAAACH5BAkBAAEALAAAAAAoACgAAAKVDI4Yy22ZnINRNqosw0Bv7i1gyHUkFj7oSaWlu3ovC8GxNso5fluz3qLVhBVeT/Lz7ZTHyxL5dDalQWPVOsQWtRnuwXaFTj9jVVh8pma9JjZ4zYSj5ZOyma7uuolffh+IR5aW97cHuBUXKGKXlKjn+DiHWMcYJah4N0lYCMlJOXipGRr5qdgoSTrqWSq6WFl2ypoaUAAAIfkECQEAAQAsAAAAACgAKAAAApaEb6HLgd/iO7FNWtcFWe+ufODGjRfoiJ2akShbueb0wtI50zm02pbvwfWEMWBQ1zKGlLIhskiEPm9R6vRXxV4ZzWT2yHOGpWMyorblKlNp8HmHEb/lCXjcW7bmtXP8Xt229OVWR1fod2eWqNfHuMjXCPkIGNileOiImVmCOEmoSfn3yXlJWmoHGhqp6ilYuWYpmTqKUgAAIfkECQEAAQAsAAAAACgAKAAAApiEH6kb58biQ3FNWtMFWW3eNVcojuFGfqnZqSebuS06w5V80/X02pKe8zFwP6EFWOT1lDFk8rGERh1TTNOocQ61Hm4Xm2VexUHpzjymViHrFbiELsefVrn6XKfnt2Q9G/+Xdie499XHd2g4h7ioOGhXGJboGAnXSBnoBwKYyfioubZJ2Hn0RuRZaflZOil56Zp6iioKSXpUAAAh+QQJAQABACwAAAAAKAAoAAACkoQRqRvnxuI7kU1a1UU5bd5tnSeOZXhmn5lWK3qNTWvRdQxP8qvaC+/yaYQzXO7BMvaUEmJRd3TsiMAgswmNYrSgZdYrTX6tSHGZO73ezuAw2uxuQ+BbeZfMxsexY35+/Qe4J1inV0g4x3WHuMhIl2jXOKT2Q+VU5fgoSUI52VfZyfkJGkha6jmY+aaYdirq+lQAACH5BAkBAAEALAAAAAAoACgAAAKWBIKpYe0L3YNKToqswUlvznigd4wiR4KhZrKt9Upqip61i9E3vMvxRdHlbEFiEXfk9YARYxOZZD6VQ2pUunBmtRXo1Lf8hMVVcNl8JafV38aM2/Fu5V16Bn63r6xt97j09+MXSFi4BniGFae3hzbH9+hYBzkpuUh5aZmHuanZOZgIuvbGiNeomCnaxxap2upaCZsq+1kAACH5BAkBAAEALAAAAAAoACgAAAKXjI8By5zf4kOxTVrXNVlv1X0d8IGZGKLnNpYtm8Lr9cqVeuOSvfOW79D9aDHizNhDJidFZhNydEahOaDH6nomtJjp1tutKoNWkvA6JqfRVLHU/QUfau9l2x7G54d1fl995xcIGAdXqMfBNadoYrhH+Mg2KBlpVpbluCiXmMnZ2Sh4GBqJ+ckIOqqJ6LmKSllZmsoq6wpQAAAh+QQJAQABACwAAAAAKAAoAAAClYx/oLvoxuJDkU1a1YUZbJ59nSd2ZXhWqbRa2/gF8Gu2DY3iqs7yrq+xBYEkYvFSM8aSSObE+ZgRl1BHFZNr7pRCavZ5BW2142hY3AN/zWtsmf12p9XxxFl2lpLn1rseztfXZjdIWIf2s5dItwjYKBgo9yg5pHgzJXTEeGlZuenpyPmpGQoKOWkYmSpaSnqKileI2FAAACH5BAkBAAEALAAAAAAoACgAAAKVjB+gu+jG4kORTVrVhRlsnn2dJ3ZleFaptFrb+CXmO9OozeL5VfP99HvAWhpiUdcwkpBH3825AwYdU8xTqlLGhtCosArKMpvfa1mMRae9VvWZfeB2XfPkeLmm18lUcBj+p5dnN8jXZ3YIGEhYuOUn45aoCDkp16hl5IjYJvjWKcnoGQpqyPlpOhr3aElaqrq56Bq7VAAAOw==");
+	height: 100%;
+	filter: alpha(opacity=25); /* support: IE8 */
+	opacity: 0.25;
+}
+.ui-progressbar-indeterminate .ui-progressbar-value {
+	background-image: none;
+}
+
+/* Component containers
+----------------------------------*/
+.ui-widget {
+	font-size: 1.1em;
+}
+.ui-widget .ui-widget {
+	font-size: 1em;
+}
+.ui-widget input,
+.ui-widget select,
+.ui-widget textarea,
+.ui-widget button {
+	font-size: 1em;
+}
+.ui-widget-content {
+	border: 1px solid #aaaaaa;
+	background: #ffffff;
+	color: #222222;
+}
+.ui-widget-content a {
+	color: #222222;
+}
+.ui-widget-header {
+	border: 1px solid #aaaaaa;
+	background: #cccccc url("../../images/progressbar/ui-bg_highlight-soft_75_cccccc_1x100.png") 50% 50% repeat-x;
+	color: #222222;
+	font-weight: bold;
+}
+.ui-widget-header a {
+	color: #222222;
+}
+
+/* Interaction states
+----------------------------------*/
+.ui-state-default,
+.ui-widget-content .ui-state-default,
+.ui-widget-header .ui-state-default {
+	border: 1px solid #d3d3d3;
+	background: #e6e6e6 url("../../images/progressbar/ui-bg_glass_75_e6e6e6_1x400.png") 50% 50% repeat-x;
+	font-weight: normal;
+	color: #555555;
+}
+.ui-state-default a,
+.ui-state-default a:link,
+.ui-state-default a:visited {
+	color: #555555;
+	text-decoration: none;
+}
+.ui-state-hover,
+.ui-widget-content .ui-state-hover,
+.ui-widget-header .ui-state-hover,
+.ui-state-focus,
+.ui-widget-content .ui-state-focus,
+.ui-widget-header .ui-state-focus {
+	border: 1px solid #999999;
+	background: #dadada url("../../images/progressbar/ui-bg_glass_75_dadada_1x400.png") 50% 50% repeat-x;
+	font-weight: normal;
+	color: #212121;
+}
+.ui-state-hover a,
+.ui-state-hover a:hover,
+.ui-state-hover a:link,
+.ui-state-hover a:visited,
+.ui-state-focus a,
+.ui-state-focus a:hover,
+.ui-state-focus a:link,
+.ui-state-focus a:visited {
+	color: #212121;
+	text-decoration: none;
+}
+.ui-state-active,
+.ui-widget-content .ui-state-active,
+.ui-widget-header .ui-state-active {
+	border: 1px solid #aaaaaa;
+	background: #ffffff url("../../images/progressbar/ui-bg_glass_65_ffffff_1x400.png") 50% 50% repeat-x;
+	font-weight: normal;
+	color: #212121;
+}
+.ui-state-active a,
+.ui-state-active a:link,
+.ui-state-active a:visited {
+	color: #212121;
+	text-decoration: none;
+}
+
+/* Interaction Cues
+----------------------------------*/
+.ui-state-highlight,
+.ui-widget-content .ui-state-highlight,
+.ui-widget-header .ui-state-highlight {
+	border: 1px solid #fcefa1;
+	background: #fbf9ee url("../../images/progressbar/ui-bg_glass_55_fbf9ee_1x400.png") 50% 50% repeat-x;
+	color: #363636;
+}
+.ui-state-highlight a,
+.ui-widget-content .ui-state-highlight a,
+.ui-widget-header .ui-state-highlight a {
+	color: #363636;
+}
+.ui-state-error,
+.ui-widget-content .ui-state-error,
+.ui-widget-header .ui-state-error {
+	border: 1px solid #cd0a0a;
+	background: #fef1ec url("../../images/progressbar/ui-bg_glass_95_fef1ec_1x400.png") 50% 50% repeat-x;
+	color: #cd0a0a;
+}
+.ui-state-error a,
+.ui-widget-content .ui-state-error a,
+.ui-widget-header .ui-state-error a {
+	color: #cd0a0a;
+}
+.ui-state-error-text,
+.ui-widget-content .ui-state-error-text,
+.ui-widget-header .ui-state-error-text {
+	color: #cd0a0a;
+}
+.ui-priority-primary,
+.ui-widget-content .ui-priority-primary,
+.ui-widget-header .ui-priority-primary {
+	font-weight: bold;
+}
+.ui-priority-secondary,
+.ui-widget-content .ui-priority-secondary,
+.ui-widget-header .ui-priority-secondary {
+	opacity: .7;
+	filter:Alpha(Opacity=70); /* support: IE8 */
+	font-weight: normal;
+}
+.ui-state-disabled,
+.ui-widget-content .ui-state-disabled,
+.ui-widget-header .ui-state-disabled {
+	opacity: .35;
+	filter:Alpha(Opacity=35); /* support: IE8 */
+	background-image: none;
+}
+.ui-state-disabled .ui-icon {
+	filter:Alpha(Opacity=35); /* support: IE8 - See #6059 */
+}
+
+/* Icons
+----------------------------------*/
+
+/* states and images */
+.ui-icon {
+	width: 16px;
+	height: 16px;
+}
+.ui-icon,
+.ui-widget-content .ui-icon {
+	background-image: url("../../images/progressbar/ui-icons_222222_256x240.png");
+}
+.ui-widget-header .ui-icon {
+	background-image: url("../../images/progressbar/ui-icons_222222_256x240.png");
+}
+.ui-state-default .ui-icon {
+	background-image: url("../../images/progressbar/ui-icons_888888_256x240.png");
+}
+.ui-state-hover .ui-icon,
+.ui-state-focus .ui-icon {
+	background-image: url("../../images/progressbar/ui-icons_454545_256x240.png");
+}
+.ui-state-active .ui-icon {
+	background-image: url("../../images/progressbar/ui-icons_454545_256x240.png");
+}
+.ui-state-highlight .ui-icon {
+	background-image: url("../../images/progressbar/ui-icons_2e83ff_256x240.png");
+}
+.ui-state-error .ui-icon,
+.ui-state-error-text .ui-icon {
+	background-image: url("../../images/progressbar/ui-icons_cd0a0a_256x240.png");
+}
+
+/* positioning */
+.ui-icon-blank { background-position: 16px 16px; }
+.ui-icon-carat-1-n { background-position: 0 0; }
+.ui-icon-carat-1-ne { background-position: -16px 0; }
+.ui-icon-carat-1-e { background-position: -32px 0; }
+.ui-icon-carat-1-se { background-position: -48px 0; }
+.ui-icon-carat-1-s { background-position: -64px 0; }
+.ui-icon-carat-1-sw { background-position: -80px 0; }
+.ui-icon-carat-1-w { background-position: -96px 0; }
+.ui-icon-carat-1-nw { background-position: -112px 0; }
+.ui-icon-carat-2-n-s { background-position: -128px 0; }
+.ui-icon-carat-2-e-w { background-position: -144px 0; }
+.ui-icon-triangle-1-n { background-position: 0 -16px; }
+.ui-icon-triangle-1-ne { background-position: -16px -16px; }
+.ui-icon-triangle-1-e { background-position: -32px -16px; }
+.ui-icon-triangle-1-se { background-position: -48px -16px; }
+.ui-icon-triangle-1-s { background-position: -64px -16px; }
+.ui-icon-triangle-1-sw { background-position: -80px -16px; }
+.ui-icon-triangle-1-w { background-position: -96px -16px; }
+.ui-icon-triangle-1-nw { background-position: -112px -16px; }
+.ui-icon-triangle-2-n-s { background-position: -128px -16px; }
+.ui-icon-triangle-2-e-w { background-position: -144px -16px; }
+.ui-icon-arrow-1-n { background-position: 0 -32px; }
+.ui-icon-arrow-1-ne { background-position: -16px -32px; }
+.ui-icon-arrow-1-e { background-position: -32px -32px; }
+.ui-icon-arrow-1-se { background-position: -48px -32px; }
+.ui-icon-arrow-1-s { background-position: -64px -32px; }
+.ui-icon-arrow-1-sw { background-position: -80px -32px; }
+.ui-icon-arrow-1-w { background-position: -96px -32px; }
+.ui-icon-arrow-1-nw { background-position: -112px -32px; }
+.ui-icon-arrow-2-n-s { background-position: -128px -32px; }
+.ui-icon-arrow-2-ne-sw { background-position: -144px -32px; }
+.ui-icon-arrow-2-e-w { background-position: -160px -32px; }
+.ui-icon-arrow-2-se-nw { background-position: -176px -32px; }
+.ui-icon-arrowstop-1-n { background-position: -192px -32px; }
+.ui-icon-arrowstop-1-e { background-position: -208px -32px; }
+.ui-icon-arrowstop-1-s { background-position: -224px -32px; }
+.ui-icon-arrowstop-1-w { background-position: -240px -32px; }
+.ui-icon-arrowthick-1-n { background-position: 0 -48px; }
+.ui-icon-arrowthick-1-ne { background-position: -16px -48px; }
+.ui-icon-arrowthick-1-e { background-position: -32px -48px; }
+.ui-icon-arrowthick-1-se { background-position: -48px -48px; }
+.ui-icon-arrowthick-1-s { background-position: -64px -48px; }
+.ui-icon-arrowthick-1-sw { background-position: -80px -48px; }
+.ui-icon-arrowthick-1-w { background-position: -96px -48px; }
+.ui-icon-arrowthick-1-nw { background-position: -112px -48px; }
+.ui-icon-arrowthick-2-n-s { background-position: -128px -48px; }
+.ui-icon-arrowthick-2-ne-sw { background-position: -144px -48px; }
+.ui-icon-arrowthick-2-e-w { background-position: -160px -48px; }
+.ui-icon-arrowthick-2-se-nw { background-position: -176px -48px; }
+.ui-icon-arrowthickstop-1-n { background-position: -192px -48px; }
+.ui-icon-arrowthickstop-1-e { background-position: -208px -48px; }
+.ui-icon-arrowthickstop-1-s { background-position: -224px -48px; }
+.ui-icon-arrowthickstop-1-w { background-position: -240px -48px; }
+.ui-icon-arrowreturnthick-1-w { background-position: 0 -64px; }
+.ui-icon-arrowreturnthick-1-n { background-position: -16px -64px; }
+.ui-icon-arrowreturnthick-1-e { background-position: -32px -64px; }
+.ui-icon-arrowreturnthick-1-s { background-position: -48px -64px; }
+.ui-icon-arrowreturn-1-w { background-position: -64px -64px; }
+.ui-icon-arrowreturn-1-n { background-position: -80px -64px; }
+.ui-icon-arrowreturn-1-e { background-position: -96px -64px; }
+.ui-icon-arrowreturn-1-s { background-position: -112px -64px; }
+.ui-icon-arrowrefresh-1-w { background-position: -128px -64px; }
+.ui-icon-arrowrefresh-1-n { background-position: -144px -64px; }
+.ui-icon-arrowrefresh-1-e { background-position: -160px -64px; }
+.ui-icon-arrowrefresh-1-s { background-position: -176px -64px; }
+.ui-icon-arrow-4 { background-position: 0 -80px; }
+.ui-icon-arrow-4-diag { background-position: -16px -80px; }
+.ui-icon-extlink { background-position: -32px -80px; }
+.ui-icon-newwin { background-position: -48px -80px; }
+.ui-icon-refresh { background-position: -64px -80px; }
+.ui-icon-shuffle { background-position: -80px -80px; }
+.ui-icon-transfer-e-w { background-position: -96px -80px; }
+.ui-icon-transferthick-e-w { background-position: -112px -80px; }
+.ui-icon-folder-collapsed { background-position: 0 -96px; }
+.ui-icon-folder-open { background-position: -16px -96px; }
+.ui-icon-document { background-position: -32px -96px; }
+.ui-icon-document-b { background-position: -48px -96px; }
+.ui-icon-note { background-position: -64px -96px; }
+.ui-icon-mail-closed { background-position: -80px -96px; }
+.ui-icon-mail-open { background-position: -96px -96px; }
+.ui-icon-suitcase { background-position: -112px -96px; }
+.ui-icon-comment { background-position: -128px -96px; }
+.ui-icon-person { background-position: -144px -96px; }
+.ui-icon-print { background-position: -160px -96px; }
+.ui-icon-trash { background-position: -176px -96px; }
+.ui-icon-locked { background-position: -192px -96px; }
+.ui-icon-unlocked { background-position: -208px -96px; }
+.ui-icon-bookmark { background-position: -224px -96px; }
+.ui-icon-tag { background-position: -240px -96px; }
+.ui-icon-home { background-position: 0 -112px; }
+.ui-icon-flag { background-position: -16px -112px; }
+.ui-icon-calendar { background-position: -32px -112px; }
+.ui-icon-cart { background-position: -48px -112px; }
+.ui-icon-pencil { background-position: -64px -112px; }
+.ui-icon-clock { background-position: -80px -112px; }
+.ui-icon-disk { background-position: -96px -112px; }
+.ui-icon-calculator { background-position: -112px -112px; }
+.ui-icon-zoomin { background-position: -128px -112px; }
+.ui-icon-zoomout { background-position: -144px -112px; }
+.ui-icon-search { background-position: -160px -112px; }
+.ui-icon-wrench { background-position: -176px -112px; }
+.ui-icon-gear { background-position: -192px -112px; }
+.ui-icon-heart { background-position: -208px -112px; }
+.ui-icon-star { background-position: -224px -112px; }
+.ui-icon-link { background-position: -240px -112px; }
+.ui-icon-cancel { background-position: 0 -128px; }
+.ui-icon-plus { background-position: -16px -128px; }
+.ui-icon-plusthick { background-position: -32px -128px; }
+.ui-icon-minus { background-position: -48px -128px; }
+.ui-icon-minusthick { background-position: -64px -128px; }
+.ui-icon-close { background-position: -80px -128px; }
+.ui-icon-closethick { background-position: -96px -128px; }
+.ui-icon-key { background-position: -112px -128px; }
+.ui-icon-lightbulb { background-position: -128px -128px; }
+.ui-icon-scissors { background-position: -144px -128px; }
+.ui-icon-clipboard { background-position: -160px -128px; }
+.ui-icon-copy { background-position: -176px -128px; }
+.ui-icon-contact { background-position: -192px -128px; }
+.ui-icon-image { background-position: -208px -128px; }
+.ui-icon-video { background-position: -224px -128px; }
+.ui-icon-script { background-position: -240px -128px; }
+.ui-icon-alert { background-position: 0 -144px; }
+.ui-icon-info { background-position: -16px -144px; }
+.ui-icon-notice { background-position: -32px -144px; }
+.ui-icon-help { background-position: -48px -144px; }
+.ui-icon-check { background-position: -64px -144px; }
+.ui-icon-bullet { background-position: -80px -144px; }
+.ui-icon-radio-on { background-position: -96px -144px; }
+.ui-icon-radio-off { background-position: -112px -144px; }
+.ui-icon-pin-w { background-position: -128px -144px; }
+.ui-icon-pin-s { background-position: -144px -144px; }
+.ui-icon-play { background-position: 0 -160px; }
+.ui-icon-pause { background-position: -16px -160px; }
+.ui-icon-seek-next { background-position: -32px -160px; }
+.ui-icon-seek-prev { background-position: -48px -160px; }
+.ui-icon-seek-end { background-position: -64px -160px; }
+.ui-icon-seek-start { background-position: -80px -160px; }
+/* ui-icon-seek-first is deprecated, use ui-icon-seek-start instead */
+.ui-icon-seek-first { background-position: -80px -160px; }
+.ui-icon-stop { background-position: -96px -160px; }
+.ui-icon-eject { background-position: -112px -160px; }
+.ui-icon-volume-off { background-position: -128px -160px; }
+.ui-icon-volume-on { background-position: -144px -160px; }
+.ui-icon-power { background-position: 0 -176px; }
+.ui-icon-signal-diag { background-position: -16px -176px; }
+.ui-icon-signal { background-position: -32px -176px; }
+.ui-icon-battery-0 { background-position: -48px -176px; }
+.ui-icon-battery-1 { background-position: -64px -176px; }
+.ui-icon-battery-2 { background-position: -80px -176px; }
+.ui-icon-battery-3 { background-position: -96px -176px; }
+.ui-icon-circle-plus { background-position: 0 -192px; }
+.ui-icon-circle-minus { background-position: -16px -192px; }
+.ui-icon-circle-close { background-position: -32px -192px; }
+.ui-icon-circle-triangle-e { background-position: -48px -192px; }
+.ui-icon-circle-triangle-s { background-position: -64px -192px; }
+.ui-icon-circle-triangle-w { background-position: -80px -192px; }
+.ui-icon-circle-triangle-n { background-position: -96px -192px; }
+.ui-icon-circle-arrow-e { background-position: -112px -192px; }
+.ui-icon-circle-arrow-s { background-position: -128px -192px; }
+.ui-icon-circle-arrow-w { background-position: -144px -192px; }
+.ui-icon-circle-arrow-n { background-position: -160px -192px; }
+.ui-icon-circle-zoomin { background-position: -176px -192px; }
+.ui-icon-circle-zoomout { background-position: -192px -192px; }
+.ui-icon-circle-check { background-position: -208px -192px; }
+.ui-icon-circlesmall-plus { background-position: 0 -208px; }
+.ui-icon-circlesmall-minus { background-position: -16px -208px; }
+.ui-icon-circlesmall-close { background-position: -32px -208px; }
+.ui-icon-squaresmall-plus { background-position: -48px -208px; }
+.ui-icon-squaresmall-minus { background-position: -64px -208px; }
+.ui-icon-squaresmall-close { background-position: -80px -208px; }
+.ui-icon-grip-dotted-vertical { background-position: 0 -224px; }
+.ui-icon-grip-dotted-horizontal { background-position: -16px -224px; }
+.ui-icon-grip-solid-vertical { background-position: -32px -224px; }
+.ui-icon-grip-solid-horizontal { background-position: -48px -224px; }
+.ui-icon-gripsmall-diagonal-se { background-position: -64px -224px; }
+.ui-icon-grip-diagonal-se { background-position: -80px -224px; }
+
+
+/* Misc visuals
+----------------------------------*/
+
+/* Corner radius */
+.ui-corner-all,
+.ui-corner-top,
+.ui-corner-left,
+.ui-corner-tl {
+	border-top-left-radius: 4px;
+}
+.ui-corner-all,
+.ui-corner-top,
+.ui-corner-right,
+.ui-corner-tr {
+	border-top-right-radius: 4px;
+}
+.ui-corner-all,
+.ui-corner-bottom,
+.ui-corner-left,
+.ui-corner-bl {
+	border-bottom-left-radius: 4px;
+}
+.ui-corner-all,
+.ui-corner-bottom,
+.ui-corner-right,
+.ui-corner-br {
+	border-bottom-right-radius: 4px;
+}
+
+/* Overlays */
+.ui-widget-overlay {
+	background: #aaaaaa;
+	opacity: .3;
+	filter: Alpha(Opacity=30); /* support: IE8 */
+}
+.ui-widget-shadow {
+	margin: -8px 0 0 -8px;
+	padding: 8px;
+	background: #aaaaaa;
+	opacity: .3;
+	filter: Alpha(Opacity=30); /* support: IE8 */
+	border-radius: 8px;
+}
+
+/*!
+ * jQuery UI CSS Framework 1.11.4
+ * http://jqueryui.com
+ *
+ * Copyright jQuery Foundation and other contributors
+ * Released under the MIT license.
+ * http://jquery.org/license
+ *
+ * http://api.jqueryui.com/category/theming/
+ */
+
+/* Layout helpers
+----------------------------------*/
+.ui-helper-hidden {
+	display: none;
+}
+.ui-helper-hidden-accessible {
+	border: 0;
+	clip: rect(0 0 0 0);
+	height: 1px;
+	margin: -1px;
+	overflow: hidden;
+	padding: 0;
+	position: absolute;
+	width: 1px;
+}
+.ui-helper-reset {
+	margin: 0;
+	padding: 0;
+	border: 0;
+	outline: 0;
+	line-height: 1.3;
+	text-decoration: none;
+	font-size: 100%;
+	list-style: none;
+}
+.ui-helper-clearfix:before,
+.ui-helper-clearfix:after {
+	content: "";
+	display: table;
+	border-collapse: collapse;
+}
+.ui-helper-clearfix:after {
+	clear: both;
+}
+.ui-helper-clearfix {
+	min-height: 0; /* support: IE7 */
+}
+.ui-helper-zfix {
+	width: 100%;
+	height: 100%;
+	top: 0;
+	left: 0;
+	position: absolute;
+	opacity: 0;
+	filter:Alpha(Opacity=0); /* support: IE8 */
+}
+
+.ui-front {
+	z-index: 100;
+}
+
+
+/* Interaction Cues
+----------------------------------*/
+.ui-state-disabled {
+	cursor: default !important;
+}
+
+
+/* Icons
+----------------------------------*/
+
+/* states and images */
+.ui-icon {
+	display: block;
+	text-indent: -99999px;
+	overflow: hidden;
+	background-repeat: no-repeat;
+}
+
+
+/* Misc visuals
+----------------------------------*/
+
+/* Overlays */
+.ui-widget-overlay {
+	position: fixed;
+	top: 0;
+	left: 0;
+	width: 100%;
+	height: 100%;
+}
+.ui-progressbar {
+	height: 2em;
+	text-align: left;
+	overflow: hidden;
+}
+.ui-progressbar .ui-progressbar-value {
+	margin: -1px;
+	height: 100%;
+}
+.ui-progressbar .ui-progressbar-overlay {
+	background: url("data:image/gif;base64,R0lGODlhKAAoAIABAAAAAP///yH/C05FVFNDQVBFMi4wAwEAAAAh+QQJAQABACwAAAAAKAAoAAACkYwNqXrdC52DS06a7MFZI+4FHBCKoDeWKXqymPqGqxvJrXZbMx7Ttc+w9XgU2FB3lOyQRWET2IFGiU9m1frDVpxZZc6bfHwv4c1YXP6k1Vdy292Fb6UkuvFtXpvWSzA+HycXJHUXiGYIiMg2R6W459gnWGfHNdjIqDWVqemH2ekpObkpOlppWUqZiqr6edqqWQAAIfkECQEAAQAsAAAAACgAKAAAApSMgZnGfaqcg1E2uuzDmmHUBR8Qil95hiPKqWn3aqtLsS18y7G1SzNeowWBENtQd+T1JktP05nzPTdJZlR6vUxNWWjV+vUWhWNkWFwxl9VpZRedYcflIOLafaa28XdsH/ynlcc1uPVDZxQIR0K25+cICCmoqCe5mGhZOfeYSUh5yJcJyrkZWWpaR8doJ2o4NYq62lAAACH5BAkBAAEALAAAAAAoACgAAAKVDI4Yy22ZnINRNqosw0Bv7i1gyHUkFj7oSaWlu3ovC8GxNso5fluz3qLVhBVeT/Lz7ZTHyxL5dDalQWPVOsQWtRnuwXaFTj9jVVh8pma9JjZ4zYSj5ZOyma7uuolffh+IR5aW97cHuBUXKGKXlKjn+DiHWMcYJah4N0lYCMlJOXipGRr5qdgoSTrqWSq6WFl2ypoaUAAAIfkECQEAAQAsAAAAACgAKAAAApaEb6HLgd/iO7FNWtcFWe+ufODGjRfoiJ2akShbueb0wtI50zm02pbvwfWEMWBQ1zKGlLIhskiEPm9R6vRXxV4ZzWT2yHOGpWMyorblKlNp8HmHEb/lCXjcW7bmtXP8Xt229OVWR1fod2eWqNfHuMjXCPkIGNileOiImVmCOEmoSfn3yXlJWmoHGhqp6ilYuWYpmTqKUgAAIfkECQEAAQAsAAAAACgAKAAAApiEH6kb58biQ3FNWtMFWW3eNVcojuFGfqnZqSebuS06w5V80/X02pKe8zFwP6EFWOT1lDFk8rGERh1TTNOocQ61Hm4Xm2VexUHpzjymViHrFbiELsefVrn6XKfnt2Q9G/+Xdie499XHd2g4h7ioOGhXGJboGAnXSBnoBwKYyfioubZJ2Hn0RuRZaflZOil56Zp6iioKSXpUAAAh+QQJAQABACwAAAAAKAAoAAACkoQRqRvnxuI7kU1a1UU5bd5tnSeOZXhmn5lWK3qNTWvRdQxP8qvaC+/yaYQzXO7BMvaUEmJRd3TsiMAgswmNYrSgZdYrTX6tSHGZO73ezuAw2uxuQ+BbeZfMxsexY35+/Qe4J1inV0g4x3WHuMhIl2jXOKT2Q+VU5fgoSUI52VfZyfkJGkha6jmY+aaYdirq+lQAACH5BAkBAAEALAAAAAAoACgAAAKWBIKpYe0L3YNKToqswUlvznigd4wiR4KhZrKt9Upqip61i9E3vMvxRdHlbEFiEXfk9YARYxOZZD6VQ2pUunBmtRXo1Lf8hMVVcNl8JafV38aM2/Fu5V16Bn63r6xt97j09+MXSFi4BniGFae3hzbH9+hYBzkpuUh5aZmHuanZOZgIuvbGiNeomCnaxxap2upaCZsq+1kAACH5BAkBAAEALAAAAAAoACgAAAKXjI8By5zf4kOxTVrXNVlv1X0d8IGZGKLnNpYtm8Lr9cqVeuOSvfOW79D9aDHizNhDJidFZhNydEahOaDH6nomtJjp1tutKoNWkvA6JqfRVLHU/QUfau9l2x7G54d1fl995xcIGAdXqMfBNadoYrhH+Mg2KBlpVpbluCiXmMnZ2Sh4GBqJ+ckIOqqJ6LmKSllZmsoq6wpQAAAh+QQJAQABACwAAAAAKAAoAAAClYx/oLvoxuJDkU1a1YUZbJ59nSd2ZXhWqbRa2/gF8Gu2DY3iqs7yrq+xBYEkYvFSM8aSSObE+ZgRl1BHFZNr7pRCavZ5BW2142hY3AN/zWtsmf12p9XxxFl2lpLn1rseztfXZjdIWIf2s5dItwjYKBgo9yg5pHgzJXTEeGlZuenpyPmpGQoKOWkYmSpaSnqKileI2FAAACH5BAkBAAEALAAAAAAoACgAAAKVjB+gu+jG4kORTVrVhRlsnn2dJ3ZleFaptFrb+CXmO9OozeL5VfP99HvAWhpiUdcwkpBH3825AwYdU8xTqlLGhtCosArKMpvfa1mMRae9VvWZfeB2XfPkeLmm18lUcBj+p5dnN8jXZ3YIGEhYuOUn45aoCDkp16hl5IjYJvjWKcnoGQpqyPlpOhr3aElaqrq56Bq7VAAAOw==");
+	height: 100%;
+	filter: alpha(opacity=25); /* support: IE8 */
+	opacity: 0.25;
+}
+.ui-progressbar-indeterminate .ui-progressbar-value {
+	background-image: none;
+}
+
+/*!
+ * jQuery UI CSS Framework 1.11.4
+ * http://jqueryui.com
+ *
+ * Copyright jQuery Foundation and other contributors
+ * Released under the MIT license.
+ * http://jquery.org/license
+ *
+ * http://api.jqueryui.com/category/theming/
+ *
+ * To view and modify this theme, visit http://jqueryui.com/themeroller/?ffDefault=Verdana%2CArial%2Csans-serif&fwDefault=normal&fsDefault=1.1em&cornerRadius=4px&bgColorHeader=cccccc&bgTextureHeader=highlight_soft&bgImgOpacityHeader=75&borderColorHeader=aaaaaa&fcHeader=222222&iconColorHeader=222222&bgColorContent=ffffff&bgTextureContent=flat&bgImgOpacityContent=75&borderColorContent=aaaaaa&fcContent=222222&iconColorContent=222222&bgColorDefault=e6e6e6&bgTextureDefault=glass&bgImgOpacityDefault=75&borderColorDefault=d3d3d3&fcDefault=555555&iconColorDefault=888888&bgColorHover=dadada&bgTextureHover=glass&bgImgOpacityHover=75&borderColorHover=999999&fcHover=212121&iconColorHover=454545&bgColorActive=ffffff&bgTextureActive=glass&bgImgOpacityActive=65&borderColorActive=aaaaaa&fcActive=212121&iconColorActive=454545&bgColorHighlight=fbf9ee&bgTextureHighlight=glass&bgImgOpacityHighlight=55&borderColorHighlight=fcefa1&fcHighlight=363636&iconColorHighlight=2e83ff&bgColorError=fef1ec&bgTextureError=glass&bgImgOpacityError=95&borderColorError=cd0a0a&fcError=cd0a0a&iconColorError=cd0a0a&bgColorOverlay=aaaaaa&bgTextureOverlay=flat&bgImgOpacityOverlay=0&opacityOverlay=30&bgColorShadow=aaaaaa&bgTextureShadow=flat&bgImgOpacityShadow=0&opacityShadow=30&thicknessShadow=8px&offsetTopShadow=-8px&offsetLeftShadow=-8px&cornerRadiusShadow=8px
+ */
+
+
+/* Component containers
+----------------------------------*/
+.ui-widget {
+	font-size: 1.1em;
+}
+.ui-widget .ui-widget {
+	font-size: 1em;
+}
+.ui-widget input,
+.ui-widget select,
+.ui-widget textarea,
+.ui-widget button {
+	font-size: 1em;
+}
+.ui-widget-content {
+	border: 1px solid #aaaaaa;
+	background: #ffffff;
+	color: #222222;
+}
+.ui-widget-content a {
+	color: #222222;
+}
+.ui-widget-header {
+	border: 1px solid #aaaaaa;
+	background: #cccccc url("../../images/progressbar/ui-bg_highlight-soft_75_cccccc_1x100.png") 50% 50% repeat-x;
+	color: #222222;
+	font-weight: bold;
+}
+.ui-widget-header a {
+	color: #222222;
+}
+
+/* Interaction states
+----------------------------------*/
+.ui-state-default,
+.ui-widget-content .ui-state-default,
+.ui-widget-header .ui-state-default {
+	border: 1px solid #d3d3d3;
+	background: #e6e6e6 url("../../images/progressbar/ui-bg_glass_75_e6e6e6_1x400.png") 50% 50% repeat-x;
+	font-weight: normal;
+	color: #555555;
+}
+.ui-state-default a,
+.ui-state-default a:link,
+.ui-state-default a:visited {
+	color: #555555;
+	text-decoration: none;
+}
+.ui-state-hover,
+.ui-widget-content .ui-state-hover,
+.ui-widget-header .ui-state-hover,
+.ui-state-focus,
+.ui-widget-content .ui-state-focus,
+.ui-widget-header .ui-state-focus {
+	border: 1px solid #999999;
+	background: #dadada url("../../images/progressbar/ui-bg_glass_75_dadada_1x400.png") 50% 50% repeat-x;
+	font-weight: normal;
+	color: #212121;
+}
+.ui-state-hover a,
+.ui-state-hover a:hover,
+.ui-state-hover a:link,
+.ui-state-hover a:visited,
+.ui-state-focus a,
+.ui-state-focus a:hover,
+.ui-state-focus a:link,
+.ui-state-focus a:visited {
+	color: #212121;
+	text-decoration: none;
+}
+.ui-state-active,
+.ui-widget-content .ui-state-active,
+.ui-widget-header .ui-state-active {
+	border: 1px solid #aaaaaa;
+	background: #ffffff url("../../images/progressbar/ui-bg_glass_65_ffffff_1x400.png") 50% 50% repeat-x;
+	font-weight: normal;
+	color: #212121;
+}
+.ui-state-active a,
+.ui-state-active a:link,
+.ui-state-active a:visited {
+	color: #212121;
+	text-decoration: none;
+}
+
+/* Interaction Cues
+----------------------------------*/
+.ui-state-highlight,
+.ui-widget-content .ui-state-highlight,
+.ui-widget-header .ui-state-highlight {
+	border: 1px solid #fcefa1;
+	background: #fbf9ee url("../../images/progressbar/ui-bg_glass_55_fbf9ee_1x400.png") 50% 50% repeat-x;
+	color: #363636;
+}
+.ui-state-highlight a,
+.ui-widget-content .ui-state-highlight a,
+.ui-widget-header .ui-state-highlight a {
+	color: #363636;
+}
+.ui-state-error,
+.ui-widget-content .ui-state-error,
+.ui-widget-header .ui-state-error {
+	border: 1px solid #cd0a0a;
+	background: #fef1ec url("../../images/progressbar/ui-bg_glass_95_fef1ec_1x400.png") 50% 50% repeat-x;
+	color: #cd0a0a;
+}
+.ui-state-error a,
+.ui-widget-content .ui-state-error a,
+.ui-widget-header .ui-state-error a {
+	color: #cd0a0a;
+}
+.ui-state-error-text,
+.ui-widget-content .ui-state-error-text,
+.ui-widget-header .ui-state-error-text {
+	color: #cd0a0a;
+}
+.ui-priority-primary,
+.ui-widget-content .ui-priority-primary,
+.ui-widget-header .ui-priority-primary {
+	font-weight: bold;
+}
+.ui-priority-secondary,
+.ui-widget-content .ui-priority-secondary,
+.ui-widget-header .ui-priority-secondary {
+	opacity: .7;
+	filter:Alpha(Opacity=70); /* support: IE8 */
+	font-weight: normal;
+}
+.ui-state-disabled,
+.ui-widget-content .ui-state-disabled,
+.ui-widget-header .ui-state-disabled {
+	opacity: .35;
+	filter:Alpha(Opacity=35); /* support: IE8 */
+	background-image: none;
+}
+.ui-state-disabled .ui-icon {
+	filter:Alpha(Opacity=35); /* support: IE8 - See #6059 */
+}
+
+/* Icons
+----------------------------------*/
+
+/* states and images */
+.ui-icon {
+	width: 16px;
+	height: 16px;
+}
+.ui-icon,
+.ui-widget-content .ui-icon {
+	background-image: url("../../images/progressbar/ui-icons_222222_256x240.png");
+}
+.ui-widget-header .ui-icon {
+	background-image: url("../../images/progressbar/ui-icons_222222_256x240.png");
+}
+.ui-state-default .ui-icon {
+	background-image: url("../../images/progressbar/ui-icons_888888_256x240.png");
+}
+.ui-state-hover .ui-icon,
+.ui-state-focus .ui-icon {
+	background-image: url("../../images/progressbar/ui-icons_454545_256x240.png");
+}
+.ui-state-active .ui-icon {
+	background-image: url("../../images/progressbar/ui-icons_454545_256x240.png");
+}
+.ui-state-highlight .ui-icon {
+	background-image: url("../../images/progressbar/ui-icons_2e83ff_256x240.png");
+}
+.ui-state-error .ui-icon,
+.ui-state-error-text .ui-icon {
+	background-image: url("../../images/progressbar/ui-icons_cd0a0a_256x240.png");
+}
+
+/* positioning */
+.ui-icon-blank { background-position: 16px 16px; }
+.ui-icon-carat-1-n { background-position: 0 0; }
+.ui-icon-carat-1-ne { background-position: -16px 0; }
+.ui-icon-carat-1-e { background-position: -32px 0; }
+.ui-icon-carat-1-se { background-position: -48px 0; }
+.ui-icon-carat-1-s { background-position: -64px 0; }
+.ui-icon-carat-1-sw { background-position: -80px 0; }
+.ui-icon-carat-1-w { background-position: -96px 0; }
+.ui-icon-carat-1-nw { background-position: -112px 0; }
+.ui-icon-carat-2-n-s { background-position: -128px 0; }
+.ui-icon-carat-2-e-w { background-position: -144px 0; }
+.ui-icon-triangle-1-n { background-position: 0 -16px; }
+.ui-icon-triangle-1-ne { background-position: -16px -16px; }
+.ui-icon-triangle-1-e { background-position: -32px -16px; }
+.ui-icon-triangle-1-se { background-position: -48px -16px; }
+.ui-icon-triangle-1-s { background-position: -64px -16px; }
+.ui-icon-triangle-1-sw { background-position: -80px -16px; }
+.ui-icon-triangle-1-w { background-position: -96px -16px; }
+.ui-icon-triangle-1-nw { background-position: -112px -16px; }
+.ui-icon-triangle-2-n-s { background-position: -128px -16px; }
+.ui-icon-triangle-2-e-w { background-position: -144px -16px; }
+.ui-icon-arrow-1-n { background-position: 0 -32px; }
+.ui-icon-arrow-1-ne { background-position: -16px -32px; }
+.ui-icon-arrow-1-e { background-position: -32px -32px; }
+.ui-icon-arrow-1-se { background-position: -48px -32px; }
+.ui-icon-arrow-1-s { background-position: -64px -32px; }
+.ui-icon-arrow-1-sw { background-position: -80px -32px; }
+.ui-icon-arrow-1-w { background-position: -96px -32px; }
+.ui-icon-arrow-1-nw { background-position: -112px -32px; }
+.ui-icon-arrow-2-n-s { background-position: -128px -32px; }
+.ui-icon-arrow-2-ne-sw { background-position: -144px -32px; }
+.ui-icon-arrow-2-e-w { background-position: -160px -32px; }
+.ui-icon-arrow-2-se-nw { background-position: -176px -32px; }
+.ui-icon-arrowstop-1-n { background-position: -192px -32px; }
+.ui-icon-arrowstop-1-e { background-position: -208px -32px; }
+.ui-icon-arrowstop-1-s { background-position: -224px -32px; }
+.ui-icon-arrowstop-1-w { background-position: -240px -32px; }
+.ui-icon-arrowthick-1-n { background-position: 0 -48px; }
+.ui-icon-arrowthick-1-ne { background-position: -16px -48px; }
+.ui-icon-arrowthick-1-e { background-position: -32px -48px; }
+.ui-icon-arrowthick-1-se { background-position: -48px -48px; }
+.ui-icon-arrowthick-1-s { background-position: -64px -48px; }
+.ui-icon-arrowthick-1-sw { background-position: -80px -48px; }
+.ui-icon-arrowthick-1-w { background-position: -96px -48px; }
+.ui-icon-arrowthick-1-nw { background-position: -112px -48px; }
+.ui-icon-arrowthick-2-n-s { background-position: -128px -48px; }
+.ui-icon-arrowthick-2-ne-sw { background-position: -144px -48px; }
+.ui-icon-arrowthick-2-e-w { background-position: -160px -48px; }
+.ui-icon-arrowthick-2-se-nw { background-position: -176px -48px; }
+.ui-icon-arrowthickstop-1-n { background-position: -192px -48px; }
+.ui-icon-arrowthickstop-1-e { background-position: -208px -48px; }
+.ui-icon-arrowthickstop-1-s { background-position: -224px -48px; }
+.ui-icon-arrowthickstop-1-w { background-position: -240px -48px; }
+.ui-icon-arrowreturnthick-1-w { background-position: 0 -64px; }
+.ui-icon-arrowreturnthick-1-n { background-position: -16px -64px; }
+.ui-icon-arrowreturnthick-1-e { background-position: -32px -64px; }
+.ui-icon-arrowreturnthick-1-s { background-position: -48px -64px; }
+.ui-icon-arrowreturn-1-w { background-position: -64px -64px; }
+.ui-icon-arrowreturn-1-n { background-position: -80px -64px; }
+.ui-icon-arrowreturn-1-e { background-position: -96px -64px; }
+.ui-icon-arrowreturn-1-s { background-position: -112px -64px; }
+.ui-icon-arrowrefresh-1-w { background-position: -128px -64px; }
+.ui-icon-arrowrefresh-1-n { background-position: -144px -64px; }
+.ui-icon-arrowrefresh-1-e { background-position: -160px -64px; }
+.ui-icon-arrowrefresh-1-s { background-position: -176px -64px; }
+.ui-icon-arrow-4 { background-position: 0 -80px; }
+.ui-icon-arrow-4-diag { background-position: -16px -80px; }
+.ui-icon-extlink { background-position: -32px -80px; }
+.ui-icon-newwin { background-position: -48px -80px; }
+.ui-icon-refresh { background-position: -64px -80px; }
+.ui-icon-shuffle { background-position: -80px -80px; }
+.ui-icon-transfer-e-w { background-position: -96px -80px; }
+.ui-icon-transferthick-e-w { background-position: -112px -80px; }
+.ui-icon-folder-collapsed { background-position: 0 -96px; }
+.ui-icon-folder-open { background-position: -16px -96px; }
+.ui-icon-document { background-position: -32px -96px; }
+.ui-icon-document-b { background-position: -48px -96px; }
+.ui-icon-note { background-position: -64px -96px; }
+.ui-icon-mail-closed { background-position: -80px -96px; }
+.ui-icon-mail-open { background-position: -96px -96px; }
+.ui-icon-suitcase { background-position: -112px -96px; }
+.ui-icon-comment { background-position: -128px -96px; }
+.ui-icon-person { background-position: -144px -96px; }
+.ui-icon-print { background-position: -160px -96px; }
+.ui-icon-trash { background-position: -176px -96px; }
+.ui-icon-locked { background-position: -192px -96px; }
+.ui-icon-unlocked { background-position: -208px -96px; }
+.ui-icon-bookmark { background-position: -224px -96px; }
+.ui-icon-tag { background-position: -240px -96px; }
+.ui-icon-home { background-position: 0 -112px; }
+.ui-icon-flag { background-position: -16px -112px; }
+.ui-icon-calendar { background-position: -32px -112px; }
+.ui-icon-cart { background-position: -48px -112px; }
+.ui-icon-pencil { background-position: -64px -112px; }
+.ui-icon-clock { background-position: -80px -112px; }
+.ui-icon-disk { background-position: -96px -112px; }
+.ui-icon-calculator { background-position: -112px -112px; }
+.ui-icon-zoomin { background-position: -128px -112px; }
+.ui-icon-zoomout { background-position: -144px -112px; }
+.ui-icon-search { background-position: -160px -112px; }
+.ui-icon-wrench { background-position: -176px -112px; }
+.ui-icon-gear { background-position: -192px -112px; }
+.ui-icon-heart { background-position: -208px -112px; }
+.ui-icon-star { background-position: -224px -112px; }
+.ui-icon-link { background-position: -240px -112px; }
+.ui-icon-cancel { background-position: 0 -128px; }
+.ui-icon-plus { background-position: -16px -128px; }
+.ui-icon-plusthick { background-position: -32px -128px; }
+.ui-icon-minus { background-position: -48px -128px; }
+.ui-icon-minusthick { background-position: -64px -128px; }
+.ui-icon-close { background-position: -80px -128px; }
+.ui-icon-closethick { background-position: -96px -128px; }
+.ui-icon-key { background-position: -112px -128px; }
+.ui-icon-lightbulb { background-position: -128px -128px; }
+.ui-icon-scissors { background-position: -144px -128px; }
+.ui-icon-clipboard { background-position: -160px -128px; }
+.ui-icon-copy { background-position: -176px -128px; }
+.ui-icon-contact { background-position: -192px -128px; }
+.ui-icon-image { background-position: -208px -128px; }
+.ui-icon-video { background-position: -224px -128px; }
+.ui-icon-script { background-position: -240px -128px; }
+.ui-icon-alert { background-position: 0 -144px; }
+.ui-icon-info { background-position: -16px -144px; }
+.ui-icon-notice { background-position: -32px -144px; }
+.ui-icon-help { background-position: -48px -144px; }
+.ui-icon-check { background-position: -64px -144px; }
+.ui-icon-bullet { background-position: -80px -144px; }
+.ui-icon-radio-on { background-position: -96px -144px; }
+.ui-icon-radio-off { background-position: -112px -144px; }
+.ui-icon-pin-w { background-position: -128px -144px; }
+.ui-icon-pin-s { background-position: -144px -144px; }
+.ui-icon-play { background-position: 0 -160px; }
+.ui-icon-pause { background-position: -16px -160px; }
+.ui-icon-seek-next { background-position: -32px -160px; }
+.ui-icon-seek-prev { background-position: -48px -160px; }
+.ui-icon-seek-end { background-position: -64px -160px; }
+.ui-icon-seek-start { background-position: -80px -160px; }
+/* ui-icon-seek-first is deprecated, use ui-icon-seek-start instead */
+.ui-icon-seek-first { background-position: -80px -160px; }
+.ui-icon-stop { background-position: -96px -160px; }
+.ui-icon-eject { background-position: -112px -160px; }
+.ui-icon-volume-off { background-position: -128px -160px; }
+.ui-icon-volume-on { background-position: -144px -160px; }
+.ui-icon-power { background-position: 0 -176px; }
+.ui-icon-signal-diag { background-position: -16px -176px; }
+.ui-icon-signal { background-position: -32px -176px; }
+.ui-icon-battery-0 { background-position: -48px -176px; }
+.ui-icon-battery-1 { background-position: -64px -176px; }
+.ui-icon-battery-2 { background-position: -80px -176px; }
+.ui-icon-battery-3 { background-position: -96px -176px; }
+.ui-icon-circle-plus { background-position: 0 -192px; }
+.ui-icon-circle-minus { background-position: -16px -192px; }
+.ui-icon-circle-close { background-position: -32px -192px; }
+.ui-icon-circle-triangle-e { background-position: -48px -192px; }
+.ui-icon-circle-triangle-s { background-position: -64px -192px; }
+.ui-icon-circle-triangle-w { background-position: -80px -192px; }
+.ui-icon-circle-triangle-n { background-position: -96px -192px; }
+.ui-icon-circle-arrow-e { background-position: -112px -192px; }
+.ui-icon-circle-arrow-s { background-position: -128px -192px; }
+.ui-icon-circle-arrow-w { background-position: -144px -192px; }
+.ui-icon-circle-arrow-n { background-position: -160px -192px; }
+.ui-icon-circle-zoomin { background-position: -176px -192px; }
+.ui-icon-circle-zoomout { background-position: -192px -192px; }
+.ui-icon-circle-check { background-position: -208px -192px; }
+.ui-icon-circlesmall-plus { background-position: 0 -208px; }
+.ui-icon-circlesmall-minus { background-position: -16px -208px; }
+.ui-icon-circlesmall-close { background-position: -32px -208px; }
+.ui-icon-squaresmall-plus { background-position: -48px -208px; }
+.ui-icon-squaresmall-minus { background-position: -64px -208px; }
+.ui-icon-squaresmall-close { background-position: -80px -208px; }
+.ui-icon-grip-dotted-vertical { background-position: 0 -224px; }
+.ui-icon-grip-dotted-horizontal { background-position: -16px -224px; }
+.ui-icon-grip-solid-vertical { background-position: -32px -224px; }
+.ui-icon-grip-solid-horizontal { background-position: -48px -224px; }
+.ui-icon-gripsmall-diagonal-se { background-position: -64px -224px; }
+.ui-icon-grip-diagonal-se { background-position: -80px -224px; }
+
+
+/* Misc visuals
+----------------------------------*/
+
+/* Corner radius */
+.ui-corner-all,
+.ui-corner-top,
+.ui-corner-left,
+.ui-corner-tl {
+	border-top-left-radius: 4px;
+}
+.ui-corner-all,
+.ui-corner-top,
+.ui-corner-right,
+.ui-corner-tr {
+	border-top-right-radius: 4px;
+}
+.ui-corner-all,
+.ui-corner-bottom,
+.ui-corner-left,
+.ui-corner-bl {
+	border-bottom-left-radius: 4px;
+}
+.ui-corner-all,
+.ui-corner-bottom,
+.ui-corner-right,
+.ui-corner-br {
+	border-bottom-right-radius: 4px;
+}
+
+/* Overlays */
+.ui-widget-overlay {
+	background: #aaaaaa;
+	opacity: .3;
+	filter: Alpha(Opacity=30); /* support: IE8 */
+}
+.ui-widget-shadow {
+	margin: -8px 0 0 -8px;
+	padding: 8px;
+	background: #aaaaaa;
+	opacity: .3;
+	filter: Alpha(Opacity=30); /* support: IE8 */
+	border-radius: 8px;
+}
+
+
+/* Custom styles
+----------------------------------*/
+
+.ui-progressbar {
+	position: relative;
+	margin-top: 1em;
+	margin-bottom: 1em;
+}
+
+.progress-label {
+	position: absolute;
+	left: 1%;
+	top: 6px;
+	font-weight: bold;
+	text-shadow: 0 0 5px #fff;
+}

--- a/assets/js/pages/page-admin.js
+++ b/assets/js/pages/page-admin.js
@@ -1,0 +1,322 @@
+/**
+ * Admin Page Javascript.
+ *
+ * Implements progress bar functionality on the plugin's Admin Page.
+ *
+ * @package WPCV_Woo_Civi
+ */
+
+/**
+ * Pass the jQuery shortcut in.
+ *
+ * @since 3.0
+ *
+ * @param {Object} $ The jQuery object.
+ */
+( function( $ ) {
+
+	/**
+	 * Create Settings class.
+	 *
+	 * @since 3.0
+	 */
+	function WPCV_Woo_Civi_Admin_Settings() {
+
+		// Prevent reference collisions.
+		var me = this;
+
+		/**
+		 * Initialise Settings.
+		 *
+		 * @since 3.0
+		 */
+		this.init = function() {
+			me.init_localisation();
+			me.init_settings();
+		};
+
+		// Init localisation array.
+		me.localisation = [];
+
+		/**
+		 * Init localisation from settings object.
+		 *
+		 * @since 3.0
+		 */
+		this.init_localisation = function() {
+			if ( 'undefined' !== typeof WPCV_Woo_Civi_Admin_Vars ) {
+				me.localisation = WPCV_Woo_Civi_Admin_Vars.localisation;
+			}
+		};
+
+		/**
+		 * Getter for localisation.
+		 *
+		 * @since 3.0
+		 *
+		 * @param {String} identifier The identifier for the desired localisation string.
+		 * @return {String} The localised string.
+		 */
+		this.get_localisation = function( identifier ) {
+			return me.localisation[identifier];
+		};
+
+		// Init settings array.
+		me.settings = [];
+
+		/**
+		 * Init settings from settings object.
+		 *
+		 * @since 3.0
+		 */
+		this.init_settings = function() {
+			if ( 'undefined' !== typeof WPCV_Woo_Civi_Admin_Vars ) {
+				me.settings = WPCV_Woo_Civi_Admin_Vars.settings;
+			}
+		};
+
+		/**
+		 * Getter for retrieving a setting.
+		 *
+		 * @since 3.0
+		 *
+		 * @param {String} The identifier for the desired setting.
+		 * @return The value of the setting.
+		 */
+		this.get_setting = function( identifier ) {
+			return me.settings[identifier];
+		};
+
+	}
+
+	/**
+	 * Create Event Object.
+	 *
+	 * @since 3.0
+	 */
+	function WPCV_Woo_Civi_Admin_Event() {
+
+		// Prevent reference collisions.
+		var me = this;
+
+		/**
+		 * Initialise Event metabox.
+		 *
+		 * This method should only be called once.
+		 *
+		 * @since 3.0
+		 */
+		this.init = function() {
+			me.ajax_url = WPCV_WCI_Admin_Settings.get_setting( 'ajax_url' );
+			me.notice_success = WPCV_WCI_Admin_Settings.get_setting( 'notice_success' );
+			me.notice_error = WPCV_WCI_Admin_Settings.get_setting( 'notice_error' );
+			me.creating_label = WPCV_WCI_Admin_Settings.get_localisation( 'creating' );
+			me.button_text = WPCV_WCI_Admin_Settings.get_localisation( 'event_button' );
+		};
+
+		/**
+		 * Do setup when jQuery reports that the DOM is ready.
+		 *
+		 * This method should only be called once.
+		 *
+		 * @since 3.0
+		 */
+		this.dom_ready = function() {
+			me.setup();
+			me.listeners();
+		};
+
+		/**
+		 * Set up Event metabox instance.
+		 *
+		 * @since 3.0
+		 */
+		this.setup = function() {
+
+			// Store submit button and AJAX nonce.
+			me.event_button = $('#wpcv_woocivi_event_process');
+			me.ajax_nonce = me.event_button.data( 'security' );
+
+		};
+
+		/**
+		 * Initialise listeners.
+		 *
+		 * This method should only be called once.
+		 *
+		 * @since 3.0
+		 */
+		this.listeners = function() {
+
+			/**
+			 * Add a click event listener to start process.
+			 *
+			 * @param {Object} event The event object.
+			 */
+			me.event_button.on( 'click', function( event ) {
+
+				var event_data = [];
+
+				// Prevent form submission.
+				if ( event.preventDefault ) {
+					event.preventDefault();
+				}
+
+				// Modify button, then show spinner.
+				me.event_button.val( me.creating_label );
+				me.event_button.prop( 'disabled', true );
+				$(this).next('.spinner').css( 'visibility', 'visible' );
+
+				// Collate data to send.
+				event_data = {
+					product_type: $('#wpcv_wci_event_product_type').val(),
+					event_id: $('#wpcv_wci_event_id').val(),
+					financial_type: $('#wpcv_wci_event_financial_type_id').val(),
+					role: $('#wpcv_wci_event_role_id').val(),
+					pfv_ids: $('#wpcv_wci_event_variations_pfv_ids').val()
+				};
+
+				// Disable form elements.
+				me.disable();
+
+				// Remove feedback.
+				$('.event_feedback .notice').remove();
+
+				// Send.
+				me.send( event_data );
+
+			});
+
+		};
+
+		/**
+		 * Send AJAX request.
+		 *
+		 * @since 3.0
+		 *
+		 * @param {Mixed} value The value to send.
+		 */
+		this.send = function( value ) {
+
+			// Define vars.
+			var data;
+
+			// Data received by WordPress.
+			data = {
+				action: 'wpcv_process_event',
+				_ajax_nonce: me.ajax_nonce,
+				value: value
+			};
+
+			// Use jQuery post.
+			$.post( me.ajax_url, data,
+
+				// Callback.
+				function( result, textStatus ) {
+
+					// Update on success, otherwise show error.
+					if ( textStatus == 'success' ) {
+						me.update( result );
+					} else {
+						if ( console.log ) {
+							console.log( textStatus );
+						}
+					}
+
+				},
+
+				// Expected format.
+				'json'
+
+			);
+
+		};
+
+		/**
+		 * Act on the result of the AJAX request.
+		 *
+		 * @since 3.0
+		 *
+		 * @param {Array} data The data received from the server.
+		 */
+		this.update = function( data ) {
+
+			// Always reset button and spinner.
+			me.event_button.val( me.button_text );
+			me.event_button.prop( 'disabled', false );
+			me.event_button.next('.spinner').css( 'visibility', 'hidden' );
+
+			// Were we successful?
+			if ( data.saved ) {
+				$('.event_feedback').append( me.notice_success );
+				$('.event_success p').html( data.notice );
+				$('.event_success').show();
+			} else {
+				$('.event_feedback').append( me.notice_error );
+				$('.event_error p').html( data.notice );
+				$('.event_error').show();
+			}
+
+			/**
+			 * Add a click event listener to notice dismiss button.
+			 *
+			 * @param {Object} event The event object.
+			 */
+			$('.event_feedback .notice-dismiss').on( 'click', function( event ) {
+				container = $(this).parent('.notice');
+				container.fadeOut( 750, function() {
+					container.remove();
+				});
+			});
+
+			// Enable form elements.
+			me.enable();
+
+		};
+
+		/**
+		 * Disable form elements during AJAX request.
+		 *
+		 * @since 3.0
+		 */
+		this.disable = function() {
+			$('#wpcv_wci_event_product_type').prop( 'disabled', true );
+			$('#wpcv_wci_event_id').prop( 'disabled', true );
+			$('#wpcv_wci_event_financial_type_id').prop( 'disabled', true );
+			$('#wpcv_wci_event_role_id').prop( 'disabled', true );
+			$('#wpcv_wci_event_variations_pfv_ids').prop( 'disabled', true );
+		};
+
+		/**
+		 * Enable form elements after AJAX request.
+		 *
+		 * @since 3.0
+		 */
+		this.enable = function() {
+			$('#wpcv_wci_event_product_type').prop( 'disabled', false );
+			$('#wpcv_wci_event_id').prop( 'disabled', false );
+			$('#wpcv_wci_event_financial_type_id').prop( 'disabled', false );
+			$('#wpcv_wci_event_role_id').prop( 'disabled', false );
+			$('#wpcv_wci_event_variations_pfv_ids').prop( 'disabled', false );
+		};
+
+	}
+
+	// Init Settings and Event classes.
+	var WPCV_WCI_Admin_Settings = new WPCV_Woo_Civi_Admin_Settings();
+	var WPCV_WCI_Admin_Event = new WPCV_Woo_Civi_Admin_Event();
+	WPCV_WCI_Admin_Settings.init();
+	WPCV_WCI_Admin_Event.init();
+
+	/**
+	 * Trigger dom_ready methods where necessary.
+	 *
+	 * @since 3.0
+	 *
+	 * @param {Object} $ The jQuery object.
+	 */
+	$(document).ready(function($) {
+		WPCV_WCI_Admin_Event.dom_ready();
+	});
+
+} )( jQuery );

--- a/assets/js/woocommerce/admin/product-quick-edit.js
+++ b/assets/js/woocommerce/admin/product-quick-edit.js
@@ -165,6 +165,13 @@
 				$(me.class_entity + ' select').val( entity_type );
 				$(me.class_financial + ' select').val( financial_type_id );
 
+				// Show elements for Variable Products.
+				if ( 'variable' === product_type ) {
+					me.show_section();
+					$(me.class_entity).show();
+					return;
+				}
+
 				// Show elements for our Custom Product Types.
 				if ( 'civicrm_contribution' === product_type ) {
 					me.show_section();
@@ -223,15 +230,21 @@
 				var value = $(this).val(), wc_inline_data, wpcv_inline_data;
 
 				// Get the references to the inline data stores.
-				//wc_inline_data = $('#woocommerce_inline_' + me.post_id);
+				wc_inline_data = $('#woocommerce_inline_' + me.post_id);
 				//wpcv_inline_data = $('#wpcv_woo_civi_inline_' + me.post_id);
 
 				// Get the Product data that we need.
-				//product_type = wc_inline_data.find( '.product_type' ).text();
+				product_type = wc_inline_data.find( '.product_type' ).text();
 				//entity_type = wpcv_inline_data.find( '.entity_type' ).text();
 
 				// Bail if empty or excluding.
 				if ( '' === value || 'civicrm_exclude' === value ) {
+					$(me.class_financial).hide();
+					return;
+				}
+
+				// Bail if Variable Product.
+				if ( 'variable' === product_type ) {
 					$(me.class_financial).hide();
 					return;
 				}

--- a/assets/templates/metaboxes/metabox-admin-contribution.php
+++ b/assets/templates/metaboxes/metabox-admin-contribution.php
@@ -1,0 +1,102 @@
+<?php
+/**
+ * Create Product for Contribution template.
+ *
+ * @package WPCV_Woo_Civi
+ * @since 3.0
+ */
+
+// Exit if accessed directly.
+defined( 'ABSPATH' ) || exit;
+
+?><!-- assets/templates/metaboxes/metabox-admin-contribution.php -->
+<?php
+
+/**
+ * Before Create Product for Contribution section.
+ *
+ * @since 3.0
+ */
+do_action( 'wpcv_woo_civi/admin/metabox/contribution/before' );
+
+?>
+<p><em><?php _e( 'Configure the Product that you want to create.', 'wpcv-woo-civi-integration' ); ?></em></p>
+
+<?php if ( empty( $metabox['args']['custom_product_type_exists'] ) ) : ?>
+	<input type="hidden" id="wpcv_wci_contribution_product_type" name="wpcv_wci_contribution_product_type" value="simple" />
+<?php endif; ?>
+
+<table class="form-table">
+	<?php if ( ! empty( $metabox['args']['custom_product_type_exists'] ) ) : ?>
+		<tr>
+			<th scope="row">
+				<label for="wpcv_wci_contribution_product_type"><?php _e( 'Product Type', 'wpcv-woo-civi-integration' ); ?></label>
+			</th>
+			<td>
+				<p>
+					<select id="wpcv_wci_contribution_product_type" name="wpcv_wci_contribution_product_type">
+						<option value="simple"><?php esc_html_e( 'Simple', 'wpcv-woo-civi-integration' ); ?></option>
+						<option value="custom"><?php esc_html_e( 'CiviCRM Contribution', 'wpcv-woo-civi-integration' ); ?></option>
+					</select>
+				</p>
+			</td>
+		</tr>
+	<?php endif; ?>
+	<tr>
+		<th scope="row">
+			<label for="wpcv_wci_contribution_financial_type_id"><?php _e( 'Financial Type', 'wpcv-woo-civi-integration' ); ?></label>
+		</th>
+		<td>
+			<?php if ( ! empty( $metabox['args']['financial_types'] ) ) : ?>
+				<p>
+					<select id="wpcv_wci_contribution_financial_type_id" name="wpcv_wci_contribution_financial_type_id">
+						<?php foreach ( $metabox['args']['financial_types'] as $key => $financial_type ) : ?>
+							<option value="<?php echo $key; ?>"><?php echo $financial_type; ?></option>
+						<?php endforeach; ?>
+					</select>
+				</p>
+				<p class="description"><?php _e( 'Choose the Financial Type that is assigned to Contribution Payments. When using a Price Field Value that is part of a Price Set, the Financial Type assigned to the Price Field Value will be used.', 'wpcv-woo-civi-integration' ); ?></p>
+			<?php endif; ?>
+		</td>
+	</tr>
+	<tr>
+		<th scope="row">
+			<label for="wpcv_wci_contribution_variations_pfv_ids"><?php _e( 'Price Field Value', 'wpcv-woo-civi-integration' ); ?></label>
+		</th>
+		<td>
+			<?php if ( ! empty( $metabox['args']['price_sets'] ) ) : ?>
+				<p>
+					<select class="wc-enhanced-select" multiple="multiple" id="wpcv_wci_contribution_variations_pfv_ids" name="wpcv_wci_contribution_variations_pfv_ids[]" style="width: 100%">
+						<?php foreach ( $metabox['args']['price_sets'] as $price_set_id => $price_set ) : ?>
+							<?php foreach ( $price_set['price_fields'] as $price_field_id => $price_field ) : ?>
+								<optgroup label="<?php echo esc_attr( sprintf( __( '%1$s (%2$s)', 'wpcv-woo-civi-integration' ), $price_set['title'], $price_field['label'] ) ); ?>">
+									<?php foreach ( $price_field['price_field_values'] as $price_field_value_id => $price_field_value ) : ?>
+										<option value="<?php echo esc_attr( $price_field_value_id ); ?>"><?php echo esc_html( $price_field_value['label'] ); ?></option>
+									<?php endforeach; ?>
+								</optgroup>
+							<?php endforeach; ?>
+						<?php endforeach; ?>
+					</select>
+				</p>
+				<p class="description"><?php _e( 'When you select more than one Price Field Value, a Variable Product will be created instead. Only add Price Field Values from the same Price Set.', 'wpcv-woo-civi-integration' ); ?></p>
+			<?php endif; ?>
+		</td>
+	</tr>
+</table>
+
+<div class="contribution_feedback">
+</div>
+
+<?php submit_button( $metabox['args']['button_title'], 'primary', 'wpcv_woocivi_contribution_process', false, [
+	'data-security' => esc_attr( wp_create_nonce( 'wpcv_manual_sync_contribution' ) ),
+	'style' => 'float: right;',
+] ); ?> <span class="spinner"></span>
+<br class="clear">
+<?php
+
+/**
+ * After Create Product for Contribution section.
+ *
+ * @since 3.0
+ */
+do_action( 'wpcv_woo_civi/admin/metabox/contribution/after' );

--- a/assets/templates/metaboxes/metabox-admin-event.php
+++ b/assets/templates/metaboxes/metabox-admin-event.php
@@ -1,0 +1,141 @@
+<?php
+/**
+ * Create Product for Event template.
+ *
+ * @package WPCV_Woo_Civi
+ * @since 3.0
+ */
+
+// Exit if accessed directly.
+defined( 'ABSPATH' ) || exit;
+
+?><!-- assets/templates/metaboxes/metabox-admin-event.php -->
+<?php
+
+/**
+ * Before Create Product for Event section.
+ *
+ * @since 3.0
+ */
+do_action( 'wpcv_woo_civi/admin/metabox/event/before' );
+
+?>
+<table class="form-table">
+	<tr>
+		<th scope="row">
+			<label for="wpcv_wci_event_id"><?php _e( 'Source Event', 'wpcv-woo-civi-integration' ); ?></label>
+		</th>
+		<td>
+			<?php if ( ! empty( $metabox['args']['events'] ) ) : ?>
+				<p>
+					<select class="wc-product-search" id="wpcv_wci_event_id" name="wpcv_wci_event_id" data-placeholder="<?php esc_attr_e( 'Search for a CiviCRM Event&hellip;', 'wpcv-woo-civi-integration' ); ?>" data-action="wpcv_woo_civi_search_events" style="width: 100%;">
+						<option value=""><?php esc_html_e( 'None', 'wpcv-woo-civi-integration' ); ?></option>
+						<?php foreach ( $metabox['args']['events'] as $event_id => $event_name ) : ?>
+							<option value="<?php echo esc_attr( $event_id ); ?>"><?php echo esc_attr( $event_name ); ?></option>
+						<?php endforeach; ?>
+					</select>
+				</p>
+				<p class="description"><?php _e( 'Choose the CiviCRM Event that you want to create the Product from.', 'wpcv-woo-civi-integration' ); ?></p>
+			<?php endif; ?>
+		</td>
+	</tr>
+</table>
+
+<hr>
+
+<p><em><?php _e( 'Configure the Product that you want to create.', 'wpcv-woo-civi-integration' ); ?></em></p>
+
+<?php if ( empty( $metabox['args']['custom_product_type_exists'] ) ) : ?>
+	<input type="hidden" id="wpcv_wci_event_product_type" name="wpcv_wci_event_product_type" value="simple" />
+<?php endif; ?>
+
+<table class="form-table">
+	<?php if ( ! empty( $metabox['args']['custom_product_type_exists'] ) ) : ?>
+		<tr>
+			<th scope="row">
+				<label for="wpcv_wci_event_product_type"><?php _e( 'Product Type', 'wpcv-woo-civi-integration' ); ?></label>
+			</th>
+			<td>
+				<p>
+					<select id="wpcv_wci_event_product_type" name="wpcv_wci_event_product_type">
+						<option value="simple"><?php esc_html_e( 'Simple', 'wpcv-woo-civi-integration' ); ?></option>
+						<option value="custom"><?php esc_html_e( 'CiviCRM Participant', 'wpcv-woo-civi-integration' ); ?></option>
+					</select>
+				</p>
+			</td>
+		</tr>
+	<?php endif; ?>
+	<tr>
+		<th scope="row">
+			<label for="wpcv_wci_event_role_id"><?php _e( 'Participant Role', 'wpcv-woo-civi-integration' ); ?></label>
+		</th>
+		<td>
+			<?php if ( ! empty( $metabox['args']['roles'] ) ) : ?>
+				<p>
+					<select id="wpcv_wci_event_role_id" name="wpcv_wci_event_role_id">
+						<?php foreach ( $metabox['args']['roles'] as $key => $role ) : ?>
+							<option value="<?php echo $key; ?>"><?php echo $role; ?></option>
+						<?php endforeach; ?>
+					</select>
+				</p>
+			<?php endif; ?>
+		</td>
+	</tr>
+	<tr>
+		<th scope="row">
+			<label for="wpcv_wci_event_financial_type_id"><?php _e( 'Financial Type', 'wpcv-woo-civi-integration' ); ?></label>
+		</th>
+		<td>
+			<?php if ( ! empty( $metabox['args']['financial_types'] ) ) : ?>
+				<p>
+					<select id="wpcv_wci_event_financial_type_id" name="wpcv_wci_event_financial_type_id">
+						<?php foreach ( $metabox['args']['financial_types'] as $key => $financial_type ) : ?>
+							<option value="<?php echo $key; ?>"><?php echo $financial_type; ?></option>
+						<?php endforeach; ?>
+					</select>
+				</p>
+				<p class="description"><?php _e( 'Choose the Financial Type that is assigned to Payments made by Participants. When using a Price Field Value that is part of a Price Set, the Financial Type assigned to the Price Field Value will be used.', 'wpcv-woo-civi-integration' ); ?></p>
+			<?php endif; ?>
+		</td>
+	</tr>
+	<tr>
+		<th scope="row">
+			<label for="wpcv_wci_event_variations_pfv_ids"><?php _e( 'Price Field Value', 'wpcv-woo-civi-integration' ); ?></label>
+		</th>
+		<td>
+			<?php if ( ! empty( $metabox['args']['price_sets'] ) ) : ?>
+				<p>
+					<select class="wc-enhanced-select" multiple="multiple" id="wpcv_wci_event_variations_pfv_ids" name="wpcv_wci_event_variations_pfv_ids[]" style="width: 100%">
+						<?php foreach ( $metabox['args']['price_sets'] as $price_set_id => $price_set ) : ?>
+							<?php foreach ( $price_set['price_fields'] as $price_field_id => $price_field ) : ?>
+								<optgroup label="<?php echo esc_attr( sprintf( __( '%1$s (%2$s)', 'wpcv-woo-civi-integration' ), $price_set['title'], $price_field['label'] ) ); ?>">
+									<?php foreach ( $price_field['price_field_values'] as $price_field_value_id => $price_field_value ) : ?>
+										<option value="<?php echo esc_attr( $price_field_value_id ); ?>"><?php echo esc_html( $price_field_value['label'] ); ?></option>
+									<?php endforeach; ?>
+								</optgroup>
+							<?php endforeach; ?>
+						<?php endforeach; ?>
+					</select>
+				</p>
+				<p class="description"><?php _e( 'When you select more than one Price Field Value, a Variable Product will be created instead. Only add Price Field Values from the same Price Set.', 'wpcv-woo-civi-integration' ); ?></p>
+			<?php endif; ?>
+		</td>
+	</tr>
+</table>
+
+<div class="event_feedback">
+</div>
+
+<?php submit_button( $metabox['args']['button_title'], 'primary', 'wpcv_woocivi_event_process', false, [
+	'data-security' => esc_attr( wp_create_nonce( 'wpcv_manual_sync_event' ) ),
+	'style' => 'float: right;',
+] ); ?> <span class="spinner"></span>
+<br class="clear">
+<?php
+
+/**
+ * After Create Product for Event section.
+ *
+ * @since 3.0
+ */
+do_action( 'wpcv_woo_civi/admin/metabox/event/after' );

--- a/assets/templates/metaboxes/metabox-admin-membership.php
+++ b/assets/templates/metaboxes/metabox-admin-membership.php
@@ -1,0 +1,118 @@
+<?php
+/**
+ * Create Product for Membership template.
+ *
+ * @package WPCV_Woo_Civi
+ * @since 3.0
+ */
+
+// Exit if accessed directly.
+defined( 'ABSPATH' ) || exit;
+
+?><!-- assets/templates/metaboxes/metabox-admin-membership.php -->
+<?php
+
+/**
+ * Before Create Product for Membership section.
+ *
+ * @since 3.0
+ */
+do_action( 'wpcv_woo_civi/admin/metabox/membership/before' );
+
+?>
+<p><em><?php _e( 'Configure the Product that you want to create.', 'wpcv-woo-civi-integration' ); ?></em></p>
+
+<?php if ( empty( $metabox['args']['custom_product_type_exists'] ) ) : ?>
+	<input type="hidden" id="wpcv_wci_membership_product_type" name="wpcv_wci_membership_product_type" value="simple" />
+<?php endif; ?>
+
+<table class="form-table">
+	<?php if ( ! empty( $metabox['args']['custom_product_type_exists'] ) ) : ?>
+		<tr>
+			<th scope="row">
+				<label for="wpcv_wci_membership_product_type"><?php _e( 'Product Type', 'wpcv-woo-civi-integration' ); ?></label>
+			</th>
+			<td>
+				<p>
+					<select id="wpcv_wci_membership_product_type" name="wpcv_wci_membership_product_type">
+						<option value="simple"><?php esc_html_e( 'Simple', 'wpcv-woo-civi-integration' ); ?></option>
+						<option value="custom"><?php esc_html_e( 'CiviCRM Membership', 'wpcv-woo-civi-integration' ); ?></option>
+					</select>
+				</p>
+			</td>
+		</tr>
+	<?php endif; ?>
+	<tr>
+		<th scope="row">
+			<label for="wpcv_wci_membership_financial_type_id"><?php _e( 'Financial Type', 'wpcv-woo-civi-integration' ); ?></label>
+		</th>
+		<td>
+			<?php if ( ! empty( $metabox['args']['financial_types'] ) ) : ?>
+				<p>
+					<select id="wpcv_wci_membership_financial_type_id" name="wpcv_wci_membership_financial_type_id">
+						<?php foreach ( $metabox['args']['financial_types'] as $key => $financial_type ) : ?>
+							<option value="<?php echo $key; ?>"><?php echo $financial_type; ?></option>
+						<?php endforeach; ?>
+					</select>
+				</p>
+				<p class="description"><?php _e( 'Choose the Financial Type that is assigned to Payments made by Members. When using a Price Field Value that is part of a Price Set, the Financial Type assigned to the Price Field Value will be used.', 'wpcv-woo-civi-integration' ); ?></p>
+			<?php endif; ?>
+		</td>
+	</tr>
+	<tr>
+		<th scope="row">
+			<label for="wpcv_wci_type_id"><?php _e( 'Membership Type', 'wpcv-woo-civi-integration' ); ?></label>
+		</th>
+		<td>
+			<?php if ( ! empty( $metabox['args']['types'] ) ) : ?>
+				<p>
+					<select id="wpcv_wci_type_id" name="wpcv_wci_type_id">
+						<?php foreach ( $metabox['args']['types'] as $type_id => $type_name ) : ?>
+							<option value="<?php echo esc_attr( $type_id ); ?>"><?php echo esc_attr( $type_name ); ?></option>
+						<?php endforeach; ?>
+					</select>
+				</p>
+			<?php endif; ?>
+		</td>
+	</tr>
+	<tr>
+		<th scope="row">
+			<label for="wpcv_wci_membership_variations_pfv_ids"><?php _e( 'Price Field Value', 'wpcv-woo-civi-integration' ); ?></label>
+		</th>
+		<td>
+			<?php if ( ! empty( $metabox['args']['price_sets'] ) ) : ?>
+				<p>
+					<select class="wc-enhanced-select" multiple="multiple" id="wpcv_wci_membership_variations_pfv_ids" name="wpcv_wci_membership_variations_pfv_ids[]" style="width: 100%">
+						<?php foreach ( $metabox['args']['price_sets'] as $price_set_id => $price_set ) : ?>
+							<?php foreach ( $price_set['price_fields'] as $price_field_id => $price_field ) : ?>
+								<optgroup label="<?php echo esc_attr( sprintf( __( '%1$s (%2$s)', 'wpcv-woo-civi-integration' ), $price_set['title'], $price_field['label'] ) ); ?>">
+									<?php foreach ( $price_field['price_field_values'] as $price_field_value_id => $price_field_value ) : ?>
+										<option value="<?php echo esc_attr( $price_field_value_id ); ?>"><?php echo esc_html( $price_field_value['label'] ); ?></option>
+									<?php endforeach; ?>
+								</optgroup>
+							<?php endforeach; ?>
+						<?php endforeach; ?>
+					</select>
+				</p>
+				<p class="description"><?php _e( 'When you select more than one Price Field Value, a Variable Product will be created instead. Only add Price Field Values from the same Price Set.', 'wpcv-woo-civi-integration' ); ?></p>
+			<?php endif; ?>
+		</td>
+	</tr>
+</table>
+
+<div class="membership_feedback">
+</div>
+
+<?php submit_button( $metabox['args']['button_title'], 'primary', 'wpcv_woocivi_membership_process', false, [
+	'data-security' => esc_attr( wp_create_nonce( 'wpcv_manual_sync_membership' ) ),
+	'style' => 'float: right;',
+] ); ?> <span class="spinner"></span>
+<br class="clear">
+<?php
+
+/**
+ * After Create Product for Membership section.
+ *
+ * @since 3.0
+ */
+do_action( 'wpcv_woo_civi/admin/metabox/membership/after' );

--- a/assets/templates/pages/page-admin.php
+++ b/assets/templates/pages/page-admin.php
@@ -1,0 +1,52 @@
+<?php
+/**
+ * Admin Page template.
+ *
+ * Handles markup for the Admin Page.
+ *
+ * @package WPCV_Woo_Civi
+ * @since 3.0
+ */
+
+?><!-- assets/templates/pages/page-admin.php -->
+<div class="wrap">
+
+	<h1><?php _e( 'Integrate CiviCRM with WooCommerce', 'wpcv-woo-civi-integration' ); ?></h1>
+
+	<p><?php _e( 'Here are some utilities for creating Products from Entities in CiviCRM.', 'wpcv-woo-civi-integration' ); ?></p>
+
+	<p><?php echo sprintf(
+		/* translators: %1$s: Opening anchor tag, %2$s: Closing anchor tag */
+		__( 'If you are looking for the WooCommerce settings for this plugin, you can %1$sfind them here%2$s.', 'wpcv-woo-civi-integration' ),
+		'<a href="' . admin_url( 'admin.php?page=wc-settings&tab=woocommerce_civicrm' ) . '">', '</a>'
+	); ?></p>
+
+	<form method="post" id="wpcv_woocivi_admin_form" action="<?php echo $this->page_submit_url_get(); ?>">
+
+		<?php wp_nonce_field( 'wpcv_woocivi_admin_action', 'wpcv_woocivi_admin_nonce' ); ?>
+		<?php wp_nonce_field( 'meta-box-order', 'meta-box-order-nonce', false ); ?>
+		<?php wp_nonce_field( 'closedpostboxes', 'closedpostboxesnonce', false ); ?>
+
+		<div id="welcome-panel" class="welcome-panel hidden">
+		</div>
+
+		<div id="dashboard-widgets-wrap">
+
+			<div id="dashboard-widgets" class="metabox-holder<?php echo $columns_css; ?>">
+
+				<div id="postbox-container-1" class="postbox-container">
+					<?php do_meta_boxes($screen->id, 'normal', '');  ?>
+				</div>
+
+				<div id="postbox-container-2" class="postbox-container">
+					<?php do_meta_boxes($screen->id, 'side', ''); ?>
+				</div>
+
+			</div><!-- #post-body -->
+			<br class="clear">
+
+		</div><!-- #poststuff -->
+
+	</form>
+
+</div><!-- /.wrap -->

--- a/assets/templates/woocommerce/admin/meta-boxes/views/html-product-data-panel-civicrm.php
+++ b/assets/templates/woocommerce/admin/meta-boxes/views/html-product-data-panel-civicrm.php
@@ -47,8 +47,8 @@ defined( 'ABSPATH' ) || exit;
 
 		// Always render the Financial Type select.
 		woocommerce_wp_select( [
-			'id' => WPCV_WCI()->products->meta_key,
-			'name' => WPCV_WCI()->products->meta_key,
+			'id' => WPCV_WCI()->products->financial_type_key,
+			'name' => WPCV_WCI()->products->financial_type_key,
 			'label' => __( 'Financial Type', 'wpcv-woo-civi-integration' ),
 			'desc_tip' => 'true',
 			'description' => __( 'The CiviCRM Financial Type for this Product.', 'wpcv-woo-civi-integration' ),

--- a/assets/templates/woocommerce/admin/meta-boxes/views/html-product-data-panel-variable.php
+++ b/assets/templates/woocommerce/admin/meta-boxes/views/html-product-data-panel-variable.php
@@ -1,0 +1,55 @@
+<?php
+/**
+ * The HTML template for the "CiviCRM Settings" Variable Product Tab.
+ *
+ * @package WPCV_Woo_Civi
+ * @since 3.0
+ */
+
+// Exit if accessed directly.
+defined( 'ABSPATH' ) || exit;
+
+?>
+<div id="civicrm_variable" class="panel woocommerce_options_panel hidden">
+
+	<?php
+
+	/**
+	 * Fires at the beginning of the "CiviCRM Settings" Variable Product Tab.
+	 *
+	 * @since 3.0
+	 */
+	do_action( 'wpcv_woo_civi/product/panel/variable/before' );
+
+	?>
+
+	<div class="options_group">
+
+		<?php
+
+		// Always render the Entity Type select.
+		woocommerce_wp_select( [
+			'id' => $this->entity_key,
+			'name' => $this->entity_key,
+			'label' => __( 'Entity Type', 'wpcv-woo-civi-integration' ),
+			'desc_tip' => 'true',
+			'description' => __( 'The CiviCRM Entity Type for this Product. Other CiviCRM settings are set in the Variations.', 'wpcv-woo-civi-integration' ),
+			'options' => $entity_options,
+		] );
+
+		?>
+
+	</div>
+
+	<?php
+
+	/**
+	 * Fires at the end of the "CiviCRM Settings" Variable Product Tab.
+	 *
+	 * @since 3.0
+	 */
+	do_action( 'wpcv_woo_civi/product/panel/variable/after' );
+
+	?>
+
+</div>

--- a/assets/templates/woocommerce/admin/meta-boxes/views/html-product-data-panel-variation.php
+++ b/assets/templates/woocommerce/admin/meta-boxes/views/html-product-data-panel-variation.php
@@ -1,0 +1,103 @@
+<?php
+/**
+ * The HTML template for the "CiviCRM Settings" Variable Product block.
+ *
+ * @package WPCV_Woo_Civi
+ * @since 3.0
+ */
+
+// Exit if accessed directly.
+defined( 'ABSPATH' ) || exit;
+
+?>
+<div class="show_if_variation_virtual options">
+
+	<?php
+
+	/**
+	 * Fires at the beginning of the Product Variation "CiviCRM Settings" block.
+	 *
+	 * @since 3.0
+	 *
+	 * @param int $loop The position in the loop.
+	 * @param array $variation_data The Product Variation data.
+	 * @param WP_Post $variation The WordPress Post data.
+	 */
+	do_action( 'wpcv_woo_civi/product/variation/block/before', $loop, $variation_data, $variation );
+
+	?>
+
+	<?php
+
+	// Always render the Financial Type select.
+	woocommerce_wp_select( [
+		'id' => $financial_type_id_key,
+		'name' => $financial_type_id_key,
+		'value' => $financial_type_id,
+		'label' => __( 'Financial Type', 'wpcv-woo-civi-integration' ),
+		'desc_tip' => 'true',
+		'description' => __( 'The CiviCRM Financial Type for this Variation.', 'wpcv-woo-civi-integration' ),
+		'wrapper_class' => 'form-row form-row-full variable_civicrm_financial_type_id',
+		'options' => $financial_type_options,
+	] );
+
+	?>
+
+	<?php
+
+	/**
+	 * Fires in the middle of the Product Variation "CiviCRM Settings" block.
+	 *
+	 * Used internally by:
+	 *
+	 * * WPCV_Woo_Civi_Membership::attributes_add_markup() (Priority: 10)
+	 * * WPCV_Woo_Civi_Participant::attributes_add_markup() (Priority: 20)
+	 *
+	 * @since 3.0
+	 *
+	 * @param int $loop The position in the loop.
+	 * @param array $variation_data The Product Variation data.
+	 * @param WP_Post $variation The WordPress Post data.
+	 * @param string $entity The CiviCRM Entity that this Product Variation is mapped to.
+	 */
+	do_action( 'wpcv_woo_civi/product/variation/block/middle', $loop, $variation_data, $variation, $entity );
+
+	?>
+
+	<?php if ( ! empty( $price_sets ) ) : ?>
+
+		<p class="form-row form-row-full variable_civicrm_pfv_id">
+			<label for="<?php echo $pfv_id_key; ?>"><?php esc_html_e( 'Price Field Value', 'wpcv-woo-civi-integration' ); ?></label>
+			<?php echo wc_help_tip( __( 'Select The Price Field for this Variation.', 'wpcv-woo-civi-integration' ) ); ?>
+			<select name="<?php echo $pfv_id_key; ?>" id="<?php echo $pfv_id_key; ?>">
+				<option value="0"><?php esc_html_e( 'Select a Price Field', 'wpcv-woo-civi-integration' ); ?></option>
+				<?php foreach ( $price_sets as $price_set_id => $price_set ) : ?>
+					<?php foreach ( $price_set['price_fields'] as $price_field_id => $price_field ) : ?>
+						<optgroup label="<?php echo esc_attr( sprintf( __( '%1$s (%2$s)', 'wpcv-woo-civi-integration' ), $price_set['title'], $price_field['label'] ) ); ?>">
+							<?php foreach ( $price_field['price_field_values'] as $price_field_value_id => $price_field_value ) : ?>
+								<option value="<?php echo esc_attr( $price_field_value_id ); ?>" <?php selected( $price_field_value_id, $pfv_id ); ?>><?php echo esc_html( $price_field_value['label'] ); ?></option>
+							<?php endforeach; ?>
+						</optgroup>
+					<?php endforeach; ?>
+				<?php endforeach; ?>
+			</select>
+		</p>
+
+	<?php endif; ?>
+
+	<?php
+
+	/**
+	 * Fires at the end of the Product Variation "CiviCRM Settings" block.
+	 *
+	 * @since 3.0
+	 *
+	 * @param int $loop The position in the loop.
+	 * @param array $variation_data The Product Variation data.
+	 * @param WP_Post $variation The WordPress Post data.
+	 */
+	do_action( 'wpcv_woo_civi/product/variation/block/after', $loop, $variation_data, $variation );
+
+	?>
+
+</div>

--- a/includes/classes/class-woo-civi-admin-migrate.php
+++ b/includes/classes/class-woo-civi-admin-migrate.php
@@ -611,6 +611,9 @@ class WPCV_Woo_Civi_Admin_Migrate {
 		// Set a stepper key.
 		$key = 'products';
 
+		// Init data.
+		$data = [];
+
 		// If this is an AJAX request, check security.
 		$result = true;
 		if ( wp_doing_ajax() ) {
@@ -787,6 +790,9 @@ class WPCV_Woo_Civi_Admin_Migrate {
 
 		// Set a stepper key.
 		$key = 'orders';
+
+		// Init data.
+		$data = [];
 
 		// If this is an AJAX request, check security.
 		$result = true;

--- a/includes/classes/class-woo-civi-admin.php
+++ b/includes/classes/class-woo-civi-admin.php
@@ -1,0 +1,1271 @@
+<?php
+/**
+ * Admin class.
+ *
+ * Handles admin tasks for this plugin.
+ *
+ * @package WPCV_Woo_Civi
+ * @since 3.0
+ */
+
+// Exit if accessed directly.
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * Admin class.
+ *
+ * @since 3.0
+ */
+class WPCV_Woo_Civi_Admin {
+
+	/**
+	 * Admin Page reference.
+	 *
+	 * @since 3.0
+	 * @access public
+	 * @var str $admin_page The Admin Page reference.
+	 */
+	public $admin_page;
+
+	/**
+	 * Admin Page slug.
+	 *
+	 * @since 3.0
+	 * @access public
+	 * @var str $admin_page_slug The slug of the Admin Page.
+	 */
+	public $admin_page_slug = 'wpcv_admin';
+
+	/**
+	 * Class constructor.
+	 *
+	 * @since 3.0
+	 */
+	public function __construct() {
+
+		// Init when this plugin is fully loaded.
+		add_action( 'wpcv_woo_civi/loaded', [ $this, 'initialise' ] );
+
+	}
+
+	/**
+	 * Initialise this object.
+	 *
+	 * @since 3.0
+	 */
+	public function initialise() {
+
+		// Register hooks.
+		$this->register_hooks();
+
+	}
+
+	/**
+	 * Register WordPress hooks.
+	 *
+	 * @since 3.0
+	 */
+	public function register_hooks() {
+
+		// Bail if WordPress Network Admin.
+		if ( is_multisite() && is_network_admin() ) {
+			return;
+		}
+
+		// Bail if not WordPress Admin.
+		if ( ! is_admin() ) {
+			return;
+		}
+
+		// Add menu item(s) to WordPress admin menu.
+		add_action( 'admin_menu', [ $this, 'admin_menu' ], 30 );
+
+		// Add our meta boxes.
+		add_action( 'add_meta_boxes', [ $this, 'meta_boxes_add' ], 11, 1 );
+
+		// Enable WooCommerce Javascripts.
+		add_filter( 'woocommerce_screen_ids', [ $this, 'admin_scripts_enable_woo' ] );
+
+		// Add AJAX handlers.
+		add_action( 'wp_ajax_wpcv_process_event', [ $this, 'event_process' ] );
+
+		return;
+
+		add_action( 'civicrm_buildForm', [ $this, 'form_event_edit' ], 10, 2 );
+		add_action( 'civicrm_buildForm', [ $this, 'form_event_snippet' ], 10, 2 );
+	    add_action( 'wpcv_woo_civi_product_create', [ $this, 'form_event_product_create' ] );
+
+	}
+
+	/**
+	 * Add Javascript on page load.
+	 *
+	 * The "CRM_Event_Form_ManageEvent_EventInfo" form is loaded twice: firstly
+	 * when the page is loaded and secondly as a "snippet" that is AJAX-loaded
+	 * into the tab container. The WordPress Media scripts need to be loaded on
+	 * page load, while the template needs to be loaded into the snippet.
+	 *
+	 * @since 0.6.3
+	 *
+	 * @param string $formName The CiviCRM form name.
+	 * @param object $form The CiviCRM form object.
+	public function form_event_edit( $formName, &$form ) {
+
+		// Is this the Event Info form?
+		if ( $formName != 'CRM_Event_Form_ManageEvent_EventInfo' ) {
+			return;
+		}
+
+		// We want the page, so grab "Print" var from form controller.
+		$controller = $form->getVar( 'controller' );
+        if ( ! empty( $controller->_print ) ) {
+        	return;
+        }
+
+		// Disallow users without upload permissions.
+		if ( ! current_user_can( 'upload_files' ) ) {
+			return;
+		}
+
+		// We *must* have a CiviCRM Event ID.
+		$event_id = $form->getVar( '_id' );
+        if ( empty( $event_id ) ) {
+        	return;
+        }
+
+		// Get the Post ID that this Event is mapped to.
+		$post_id = $this->plugin->db->get_eo_event_id_by_civi_event_id( $event_id );
+		if ( $post_id === false ) {
+			return;
+		}
+
+		// Enqueue the WordPress media scripts.
+		wp_enqueue_media();
+
+		// Enqueue our Javascript in footer.
+		wp_enqueue_script(
+			'ceo-feature-image',
+			CIVICRM_WP_EVENT_ORGANISER_URL . 'assets/js/civi-eo-feature-image.js',
+			[ 'jquery' ],
+			CIVICRM_WP_EVENT_ORGANISER_VERSION,
+			true // In footer.
+		);
+
+		// Init localisation.
+		$localisation = [
+			'title' => __( 'Choose Feature Image', 'civicrm-event-organiser' ),
+			'button' => __( 'Set Feature Image', 'civicrm-event-organiser' ),
+		];
+
+		/// Init settings.
+		$settings = [
+			'ajax_url' => admin_url( 'admin-ajax.php' ),
+			'loading' => CIVICRM_WP_EVENT_ORGANISER_URL . 'assets/images/loading.gif',
+		];
+
+		// Localisation array.
+		$vars = [
+			'localisation' => $localisation,
+			'settings' => $settings,
+		];
+
+		// Localise the WordPress way.
+		wp_localize_script(
+			'ceo-feature-image',
+			'CEO_Feature_Image_Settings',
+			$vars
+		);
+
+	}
+	 */
+
+	/**
+	 * Inject template into AJAX-loaded snippet.
+	 *
+	 * @see self::form_event_edit()
+	 *
+	 * @since 0.6.3
+	 *
+	 * @param string $formName The CiviCRM form name.
+	 * @param object $form The CiviCRM form object.
+	public function form_event_snippet( $formName, &$form ) {
+
+		// Is this the Event Info form?
+		if ( $formName != 'CRM_Event_Form_ManageEvent_EventInfo' ) {
+			return;
+		}
+
+		// We want the snippet, so grab "Print" var from form controller.
+		$controller = $form->getVar( 'controller' );
+        if ( empty( $controller->_print ) OR $controller->_print !== 'json' ) {
+        	return;
+        }
+
+		// Disallow users without upload permissions.
+		if ( ! current_user_can( 'upload_files' ) ) {
+			return;
+		}
+
+		// We need the CiviCRM Event ID.
+		$event_id = $form->getVar( '_id' );
+        if ( empty( $event_id ) ) {
+        	return;
+        }
+
+		// Get the Post ID that this Event is mapped to.
+		$post_id = $this->plugin->db->get_eo_event_id_by_civi_event_id( $event_id );
+		if ( $post_id === false ) {
+			return;
+		}
+
+		// Does this Event have a Feature Image?
+		$attachment_id = '';
+		if ( has_post_thumbnail( $post_id ) ) {
+			$attachment_id = get_post_thumbnail_id( $post_id );
+		}
+
+		// Add hidden field to hold the Attachment ID.
+		$hidden_field = $form->add( 'hidden', 'ceo_attachment_id', $attachment_id );
+
+		// Get the image markup.
+		$placeholder_url = CIVICRM_WP_EVENT_ORGANISER_URL . 'assets/images/placeholder.gif';
+		$markup = '<img src="' . $placeholder_url . '" class="wp-post-image" style="display: none;">';
+		if ( ! empty( $attachment_id ) ) {
+			$markup = get_the_post_thumbnail( $post_id, 'medium' );
+		}
+
+		// Add image markup.
+		$form->assign(
+			'ceo_attachment_markup',
+			$markup
+		);
+
+		// Add button ID.
+		$form->assign(
+			'ceo_attachment_id_button_id',
+			'ceo-feature-image-switcher-' . $post_id
+		);
+
+		// Add button text.
+		$form->assign(
+			'ceo_attachment_id_button',
+			__( 'Choose Feature Image', 'civicrm-event-organiser' )
+		);
+
+		// Add help text.
+		$form->assign(
+			'ceo_attachment_id_help',
+			__( 'If you would like to add a Feature Image to the Event Organiser Event, choose one here.', 'civicrm-event-organiser' )
+		);
+
+		// Insert template block into the page.
+		CRM_Core_Region::instance('page-body')->add([
+			'template' => 'ceo-featured-image.tpl'
+		]);
+
+	}
+	 */
+
+	/**
+	 * AJAX handler for Feature Image calls.
+	 *
+	 * @since 0.6.3
+	public function form_event_image() {
+
+		// Init response.
+		$data = [
+			'success' => 'false',
+		];
+
+		// Disallow users without upload permissions.
+		if ( ! current_user_can( 'upload_files' ) ) {
+			return $data;
+		}
+
+		// Get Attachment ID.
+		$attachment_id = isset( $_POST['attachment_id'] ) ? (int) trim( $_POST['attachment_id'] ) : 0;
+		if ( ! is_numeric( $attachment_id ) OR $attachment_id === 0 ) {
+			return $data;
+		}
+
+		// Handle Feature Image if there is a Post ID.
+		$post_id = isset( $_POST['post_id'] ) ? (int) trim( $_POST['post_id'] ) : 0;
+		if ( is_numeric( $post_id ) AND $post_id !== 0 ) {
+
+			// Set Feature Image.
+			set_post_thumbnail( $post_id, $attachment_id );
+
+			// Get the Feature Image markup.
+			$markup = get_the_post_thumbnail( $post_id, 'medium' );
+
+		} else {
+
+			// Filter the image class.
+			add_filter( 'wp_get_attachment_image_attributes', [ $this, 'form_event_image_filter' ], 10, 1 );
+
+			// Get the Attachment Image markup.
+			$markup = wp_get_attachment_image( $attachment_id, 'medium', false );
+
+			// Remove filter.
+			remove_filter( 'wp_get_attachment_image_attributes', [ $this, 'form_event_image_filter' ] );
+
+		}
+
+		// Add to data.
+		$data['markup'] = $markup;
+
+		// Overwrite flag.
+		$data['success'] = 'true';
+
+		// Send data to browser.
+		wp_send_json( $data );
+
+	}
+	 */
+
+	// -------------------------------------------------------------------------
+
+	/**
+	 * Add our admin page(s) to the WordPress admin menu.
+	 *
+	 * @since 3.0
+	 */
+	public function admin_menu() {
+
+		// We must be network admin in Multisite.
+		if ( is_multisite() AND ! is_super_admin() ) {
+			return;
+		}
+
+		// Check user permissions.
+		if ( ! current_user_can( 'manage_options' ) ) {
+			return;
+		}
+
+		// Add our Admin page to the CiviCRM menu.
+		$this->admin_page = add_submenu_page(
+			'CiviCRM', // Parent slug.
+			__( 'Integrate CiviCRM with WooCommerce', 'wpcv-woo-civi-integration' ), // Page title.
+			__( 'WooCommerce', 'wpcv-woo-civi-integration' ), // Menu title.
+			'manage_options', // Required caps.
+			$this->admin_page_slug, // Slug name.
+			[ $this, 'page_admin' ], // Callback.
+			10
+		);
+
+		// Register our form submit hander.
+		add_action( 'load-' . $this->admin_page, [ $this, 'form_submitted' ] );
+
+		// Add styles and scripts only on our Admin page.
+		// @see wp-admin/admin-header.php
+		add_action( 'admin_head-' . $this->admin_page, [ $this, 'admin_head' ] );
+		add_action( 'admin_print_styles-' . $this->admin_page, [ $this, 'admin_styles' ] );
+		add_action( 'admin_print_scripts-' . $this->admin_page, [ $this, 'admin_scripts' ] );
+
+		/**
+		 * Broadcast that the admin page has been added.
+		 *
+		 * @since 3.0
+		 *
+		 * @param string $admin_page The handle of the admin page.
+		 */
+		do_action( 'wpcv_woo_civi/admin/admin_page', $this->admin_page );
+
+	}
+
+	/**
+	 * Add metabox scripts and initialise plugin help.
+	 *
+	 * @since 3.0
+	 */
+	public function admin_head() {
+
+		// Enqueue WordPress scripts.
+		wp_enqueue_script( 'common' );
+		wp_enqueue_script( 'jquery-ui-sortable' );
+		wp_enqueue_script( 'dashboard' );
+
+	}
+
+	/**
+	 * Enqueue required scripts.
+	 *
+	 * @since 3.0
+	 */
+	public function admin_scripts() {
+
+		$handle = 'wpcv_woocivi_admin_js';
+
+		// Enqueue Javascript.
+		wp_enqueue_script(
+			$handle,
+			plugins_url( 'assets/js/pages/page-admin.js', WPCV_WOO_CIVI_FILE ),
+			[ 'jquery', 'jquery-ui-core', 'jquery-ui-progressbar' ],
+			WPCV_WOO_CIVI_VERSION // Version.
+		);
+
+		$localisation = [
+			'event_button' => esc_html__( 'Create Product', 'wpcv-woo-civi-integration' ),
+			'creating' => esc_html__( 'Creating...', 'wpcv-woo-civi-integration' ),
+		];
+
+		$settings = [
+			'ajax_url' => admin_url( 'admin-ajax.php' ),
+			'notice_success' => '<div class="event_success notice notice-success inline is-dismissible" style="background-color: #f7f7f7; display: none;"><p></p><button type="button" class="notice-dismiss"><span class="screen-reader-text">' . esc_html__( 'Dismiss this notice.', 'wpcv-woo-civi-integration' ) . '</span></button></div>',
+			'notice_error' => '<div class="event_error notice notice-error inline is-dismissible" style="background-color: #f7f7f7; display: none;"><p></p><button type="button" class="notice-dismiss"><span class="screen-reader-text">' . esc_html__( 'Dismiss this notice.', 'wpcv-woo-civi-integration' ) . '</span></button></div>',
+		];
+
+		$vars = [
+			'localisation' => $localisation,
+			'settings' => $settings,
+		];
+
+		/**
+		 * Filter the Javascript vars before localising the script.
+		 *
+		 * @since 3.0
+		 *
+		 * @param array $vars The array of Javascript vars.
+		 */
+		$vars = apply_filters( 'wpcv_woo_civi/admin/admin_scripts/vars', $vars );
+
+		// Localise the WordPress way.
+		wp_localize_script( $handle, 'WPCV_Woo_Civi_Admin_Vars', $vars );
+
+		/**
+		 * Broadcast that the script has been enqueued.
+		 *
+		 * @since 3.0
+		 *
+		 * @param string $handle The handle of the script.
+		 * @param array $vars The array of Javascript vars.
+		 */
+		do_action( 'wpcv_woo_civi/admin/admin_scripts/enqueued', $handle, $vars );
+
+	}
+
+	/**
+	 * Force WooCommerce Javascripts to load by adding our Admin Page Screen ID.
+	 *
+	 * @since 3.0
+	 *
+	 * @param array $screen_ids The existing array of WooCommerce Screen IDs.
+	 * @return array $screen_ids The modified array of WooCommerce Screen IDs.
+	 */
+	public function admin_scripts_enable_woo( $screen_ids ) {
+		$screen_ids[] = 'civicrm_page_' . $this->admin_page_slug;
+		return $screen_ids;
+	}
+
+	/**
+	 * Enqueue any styles needed by our Admin Page.
+	 *
+	 * @since 3.0
+	 */
+	public function admin_styles() {
+
+		// Enqueue CSS.
+		wp_enqueue_style(
+			'wpcv-woo-civi-admin',
+			WPCV_WOO_CIVI_URL . 'assets/css/pages/page-admin.css',
+			null,
+			WPCV_WOO_CIVI_VERSION,
+			'all' // Media.
+		);
+
+	}
+
+	/**
+	 * Show our Admin page.
+	 *
+	 * @since 3.0
+	 */
+	public function page_admin() {
+
+		// We must be network admin in Multisite.
+		if ( is_multisite() AND ! is_super_admin() ) {
+			wp_die( __( 'You do not have permission to access this page.', 'wpcv-woo-civi-integration' ) );
+		}
+
+		// Check user permissions.
+		if ( ! current_user_can( 'manage_options' ) ) {
+			wp_die( __( 'You do not have permission to access this page.', 'wpcv-woo-civi-integration' ) );
+		}
+
+		// Get current screen.
+		$screen = get_current_screen();
+
+		/**
+		 * Allow meta boxes to be added to this screen.
+		 *
+		 * The Screen ID to use is: "civicrm_page_wpcv_woocivi_admin".
+		 *
+		 * @since 3.0
+		 *
+		 * @param string $screen_id The ID of the current screen.
+		 */
+		do_action( 'add_meta_boxes', $screen->id, null );
+
+		// Get the column CSS class.
+		$columns = absint( $screen->get_columns() );
+		$columns_css = '';
+		if ( $columns ) {
+			$columns_css = " columns-$columns";
+		}
+
+		// Include template file.
+		include WPCV_WOO_CIVI_PATH . 'assets/templates/pages/page-admin.php';
+
+	}
+
+	/**
+	 * Get the URL for the form action.
+	 *
+	 * @since 3.0
+	 *
+	 * @return string $target_url The URL for the admin form action.
+	 */
+	public function page_submit_url_get() {
+
+		// Sanitise admin page url.
+		$target_url = $_SERVER['REQUEST_URI'];
+		$url_array = explode( '&', $target_url );
+
+		// Strip flag, if present, and rebuild.
+		if ( ! empty( $url_array ) ) {
+			$url_raw = str_replace( '&amp;updated=true', '', $url_array[0] );
+			$target_url = htmlentities( $url_raw . '&updated=true' );
+		}
+
+		return $target_url;
+
+	}
+
+	/**
+	 * Register meta boxes.
+	 *
+	 * @since 3.0
+	 *
+	 * @param string $screen_id The Admin Page Screen ID.
+	 */
+	public function meta_boxes_add( $screen_id ) {
+
+		// Define valid Screen IDs.
+		$screen_ids = [
+			'civicrm_page_' . $this->admin_page_slug,
+		];
+
+		// Bail if not the Screen ID we want.
+		if ( ! in_array( $screen_id, $screen_ids ) ) {
+			return;
+		}
+
+		// Bail if user cannot access CiviCRM.
+		if ( ! current_user_can( 'access_civicrm' ) ) {
+			return;
+		}
+
+		// Init common data.
+		$data = [];
+
+		// Get the array of Financial Types.
+		$data['financial_types'] = [
+			'' => __( 'Select a Financial Type', 'wpcv-woo-civi-integration' ),
+		] + WPCV_WCI()->helper->get_financial_types();
+
+		// Get the array of Price Sets.
+		$data['price_sets'] = WPCV_WCI()->helper->get_price_sets_populated();
+
+		/**
+		 * Filter the common metabox data.
+		 *
+		 * @since 3.0
+		 *
+		 * @param array $vars The array of metabox data.
+		 */
+		$data = apply_filters( 'wpcv_woo_civi/admin/meta_boxes_add/data', $data );
+
+		/*
+		// Define a handle for the "Create Product for Contribution" metabox.
+		$handle = 'wpcv_woocivi_contribution_to_product';
+
+		// Add the metabox.
+		add_meta_box(
+			$handle,
+			__( 'Create Product for Contribution', 'wpcv-woo-civi-integration' ),
+			[ $this, 'meta_box_contribution_render' ], // Callback.
+			$screen_id, // Screen ID.
+			'normal', // Column: options are 'normal' and 'side'.
+			'core', // Vertical placement: options are 'core', 'high', 'low'.
+			$data
+		);
+
+		// Make this metabox closed by default.
+		//add_filter( "postbox_classes_{$screen_id}_{$handle}", [ $this, 'meta_box_closed' ] );
+		*/
+
+		/*
+		// Define a handle for the "Create Product for Membership" metabox.
+		$handle = 'wpcv_woocivi_membership_to_product';
+
+		// Add the metabox.
+		add_meta_box(
+			$handle,
+			__( 'Create Product for Membership', 'wpcv-woo-civi-integration' ),
+			[ $this, 'meta_box_membership_render' ], // Callback.
+			$screen_id, // Screen ID.
+			'normal', // Column: options are 'normal' and 'side'.
+			'core', // Vertical placement: options are 'core', 'high', 'low'.
+			$data
+		);
+
+		// Make this metabox closed by default.
+		//add_filter( "postbox_classes_{$screen_id}_{$handle}", [ $this, 'meta_box_closed' ] );
+		*/
+
+		// Define a handle for the "Create Product for Event" metabox.
+		$handle = 'wpcv_woocivi_event_to_product';
+
+		// Add the metabox.
+		add_meta_box(
+			$handle,
+			__( 'Create Product for Event', 'wpcv-woo-civi-integration' ),
+			[ $this, 'meta_box_event_render' ], // Callback.
+			$screen_id, // Screen ID.
+			'normal', // Column: options are 'normal' and 'side'.
+			'core', // Vertical placement: options are 'core', 'high', 'low'.
+			$data
+		);
+
+		// Make this metabox closed by default.
+		//add_filter( "postbox_classes_{$screen_id}_{$handle}", [ $this, 'meta_box_closed' ] );
+
+		/**
+		 * Broadcast that the metaboxes have been added.
+		 *
+		 * @since 3.0
+		 *
+		 * @param string $screen_id The Screen indentifier.
+		 * @param array $vars The array of metabox data.
+		 */
+		do_action( 'wpcv_woo_civi/admin/meta_boxes_added', $screen_id, $data );
+
+	}
+
+	/**
+	 * Load our metaboxes as closed by default.
+	 *
+	 * @since 3.0
+	 *
+	 * @param string[] $classes An array of postbox classes.
+	 */
+	public function meta_box_closed( $classes ) {
+
+		// Add closed class.
+		if ( is_array( $classes ) ) {
+			if ( ! in_array( 'closed', $classes ) ) {
+				$classes[] = 'closed';
+			}
+		}
+
+		return $classes;
+
+	}
+
+	/**
+	 * Render "Create Product for Contribution" meta box on Admin screen.
+	 *
+	 * @since 3.0
+	 *
+	 * @param mixed $unused Unused param.
+	 * @param array $metabox Array containing id, title, callback, and args elements.
+	 */
+	public function meta_box_contribution_render( $unused, $metabox ) {
+
+		// Set the Event button title.
+		$metabox['args']['button_title'] = esc_html__( 'Create Product', 'wpcv-woo-civi-integration' );
+
+		// Assume there is no Custom Contribution Product Type.
+		$metabox['args']['custom_product_type_exists'] = false;
+		if ( WPCV_WCI()->contribution->active ) {
+			$metabox['args']['custom_product_type_exists'] = true;
+		}
+
+		// Include template file.
+		include WPCV_WOO_CIVI_PATH . 'assets/templates/metaboxes/metabox-admin-contribution.php';
+
+	}
+
+	/**
+	 * Render "Create Product for Membership" meta box on Admin screen.
+	 *
+	 * @since 3.0
+	 *
+	 * @param mixed $unused Unused param.
+	 * @param array $metabox Array containing id, title, callback, and args elements.
+	 */
+	public function meta_box_membership_render( $unused, $metabox ) {
+
+		// Get the array of Membership Types.
+		$metabox['args']['types'] = WPCV_WCI()->membership->get_membership_types_options();
+
+		// Set the Event button title.
+		$metabox['args']['button_title'] = esc_html__( 'Create Product', 'wpcv-woo-civi-integration' );
+
+		// Assume there is no Custom Membership Product Type.
+		$metabox['args']['custom_product_type_exists'] = false;
+		if ( WPCV_WCI()->membership->active ) {
+			$metabox['args']['custom_product_type_exists'] = true;
+		}
+
+		// Include template file.
+		include WPCV_WOO_CIVI_PATH . 'assets/templates/metaboxes/metabox-admin-membership.php';
+
+	}
+
+	/**
+	 * Render "Create Product for Event" meta box on Admin screen.
+	 *
+	 * @since 3.0
+	 *
+	 * @param mixed $unused Unused param.
+	 * @param array $metabox Array containing id, title, callback, and args elements.
+	 */
+	public function meta_box_event_render( $unused, $metabox ) {
+
+		// Get the array of Events.
+		$metabox['args']['events'] = WPCV_WCI()->participant->get_event_options();
+
+		// Get the array of Participant Roles.
+		$metabox['args']['roles'] = WPCV_WCI()->participant->get_participant_roles_options();
+
+		// Set the Event button title.
+		$metabox['args']['button_title'] = esc_html__( 'Create Product', 'wpcv-woo-civi-integration' );
+
+		// Assume there is no Custom Participant Product Type.
+		$metabox['args']['custom_product_type_exists'] = false;
+		if ( WPCV_WCI()->participant->active ) {
+			$metabox['args']['custom_product_type_exists'] = true;
+		}
+
+		// Include template file.
+		include WPCV_WOO_CIVI_PATH . 'assets/templates/metaboxes/metabox-admin-event.php';
+
+	}
+
+	/**
+	 * Perform actions when the form has been submitted.
+	 *
+	 * At the moment only the form in the "Create Product for Event" metabox
+	 * can be submitted without Javascript being enabled.
+	 *
+	 * @since 3.0
+	 */
+	public function form_submitted() {
+
+		/*
+		// If our "Create Product for Contribution" button was clicked.
+		if ( ! empty( $_POST['wpcv_woocivi_contribution_process'] ) ) {
+			$this->form_nonce_check();
+			$this->contribution_process();
+			$this->form_redirect();
+		}
+		*/
+
+		/*
+		// If our "Create Product for Membership" button was clicked.
+		if ( ! empty( $_POST['wpcv_woocivi_membership_process'] ) ) {
+			$this->form_nonce_check();
+			$this->membership_process();
+			$this->form_redirect();
+		}
+		*/
+
+		// If our "Create Product for Event" button was clicked.
+		if ( ! empty( $_POST['wpcv_woocivi_event_process'] ) ) {
+			$this->form_nonce_check();
+			$this->event_process();
+			$this->form_redirect();
+		}
+
+		/**
+		 * Broadcast that the form has been submitted.
+		 *
+		 * @since 3.0
+		 */
+		do_action( 'wpcv_woo_civi/admin/form_submitted' );
+
+	}
+
+	/**
+	 * Check the nonce.
+	 *
+	 * @since 3.0
+	 */
+	private function form_nonce_check() {
+
+		// Do we trust the source of the data?
+		check_admin_referer( 'wpcv_woocivi_admin_action', 'wpcv_woocivi_admin_nonce' );
+
+	}
+
+	/**
+	 * Redirect to the Settings page with an optional extra param.
+	 *
+	 * @since 3.0
+	 *
+	 * @param str $mode Pass 'updated' to append the extra param.
+	 */
+	private function form_redirect( $mode = '' ) {
+
+		// Our default array of arguments.
+		$args = [
+			'page' => $this->admin_page_slug,
+		];
+
+		// Maybe append param.
+		if ( $mode === 'updated' ) {
+			$args['settings-updated'] = 'true';
+		}
+
+		// Redirect to our admin page.
+		wp_safe_redirect( add_query_arg( $args, admin_url( 'admin.php' ) ) );
+		exit;
+
+	}
+
+	/**
+	 * The "Process Event" AJAX callback.
+	 *
+	 * @since 3.0
+	 */
+	public function event_process() {
+
+		// Default response.
+		$data = [
+			'notice' => __( 'Could not create WooCommerce Product.', 'wpcv-woo-civi-integration' ),
+			'saved' => false,
+		];
+
+		// If this is an AJAX request, check security.
+		$result = true;
+		if ( wp_doing_ajax() ) {
+			$result = check_ajax_referer( 'wpcv_manual_sync_event', false, false );
+		}
+
+		// If we get an error.
+		if ( $result === false ) {
+			$data['notice'] = __( 'Authentication failed.', 'wpcv-woo-civi-integration' );
+			wp_send_json( $data );
+		}
+
+		// Get inputs from POST and validate.
+		$inputs = $this->event_inputs_parse( $data );
+
+		// Get the CiviCRM Event data.
+		$event = WPCV_WCI()->participant->get_event_by_id( $inputs['event_id'] );
+		if ( $event === false ) {
+			$data['notice'] = __( 'Unrecognised Event.', 'wpcv-woo-civi-integration' );
+			wp_send_json( $data );
+		}
+
+		// Create Product based on Price Field Value count and selected type.
+		if ( count( $inputs['pfv_ids'] ) === 1 ) {
+			if ( $inputs['product_type'] === 'simple' ) {
+				$product = $this->event_product_create_simple( $inputs, $event );
+			} else {
+				$product = $this->event_product_create_custom( $inputs, $event );
+			}
+		} else {
+			$product = $this->event_product_create_variable( $inputs, $event );
+		}
+
+		// Build success data.
+		$data['saved'] = true;
+		$data['notice'] = sprintf(
+			/* translators: %1$s: Opening anchor tag, %2$s: Closing anchor tag */
+			__( 'WooCommerce Product successfully created. %1$sView Product%1$s', 'wpcv-woo-civi-integration' ),
+			'<a href="' . $product['permalink'] . '">', '</a>'
+		);
+
+		// Return the data.
+		wp_send_json( $data );
+
+	}
+
+	/**
+	 * Gets the inputs from the POST array and validates them.
+	 *
+	 * @since 3.0
+	 *
+	 * @param array $data The default AJAX return array.
+	 * @return array $inputs The extracted and validated data.
+	 */
+	public function event_inputs_parse( $data ) {
+
+		// Bail if there are no valid values.
+		$values = isset( $_POST['value'] ) ? (array) $_POST['value'] : [];
+		if ( empty( $values ) ) {
+			$data['notice'] = __( 'Unrecognised parameters.', 'wpcv-woo-civi-integration' );
+			wp_send_json( $data );
+		}
+
+		// Bail if the Product Type is not valid.
+		$product_type = isset( $_POST['value']['product_type'] ) ? sanitize_key( $_POST['value']['product_type'] ) : '';
+		if ( empty( $product_type ) || ! in_array( $product_type, [ 'simple', 'custom' ] ) ) {
+			$data['notice'] = __( 'Unrecognised Product Type.', 'wpcv-woo-civi-integration' );
+			wp_send_json( $data );
+		}
+
+		// Bail if the Financial Type is not valid.
+		$financial_type_id = isset( $_POST['value']['financial_type'] ) ? (int) $_POST['value']['financial_type'] : 0;
+		if ( empty( $financial_type_id ) ) {
+			$data['notice'] = __( 'Unrecognised Financial Type.', 'wpcv-woo-civi-integration' );
+			wp_send_json( $data );
+		}
+
+		// Bail if the Price Field Values are not valid.
+		$pfv_ids = isset( $_POST['value']['pfv_ids'] ) ? array_map( 'intval', $_POST['value']['pfv_ids'] ) : [];
+		if ( empty( $pfv_ids ) ) {
+			$data['notice'] = __( 'Unrecognised Price Field Values.', 'wpcv-woo-civi-integration' );
+			wp_send_json( $data );
+		}
+
+		// Bail if the Event ID is not valid.
+		$event_id = isset( $_POST['value']['event_id'] ) ? (int) $_POST['value']['event_id'] : 0;
+		if ( empty( $event_id ) ) {
+			$data['notice'] = __( 'Unrecognised Event ID.', 'wpcv-woo-civi-integration' );
+			wp_send_json( $data );
+		}
+
+		// Bail if the Participant Role is not valid.
+		$role_id = isset( $_POST['value']['role'] ) ? (int) $_POST['value']['role'] : 0;
+		if ( empty( $role_id ) ) {
+			$data['notice'] = __( 'Unrecognised Participant Role.', 'wpcv-woo-civi-integration' );
+			wp_send_json( $data );
+		}
+
+		// Combine inputs into an array.
+		$inputs = [
+			'product_type' => $product_type,
+			'financial_type_id' => $financial_type_id,
+			'pfv_ids' => $pfv_ids,
+			'event_id' => $event_id,
+			'role_id' => $role_id,
+		];
+
+		return $inputs;
+
+	}
+
+	/**
+	 * Creates a new Simple Product.
+	 *
+	 * @since 3.0
+	 *
+	 * @param array $inputs The validated POST data.
+	 * @param array $event The array of CiviCRM Event data.
+	 * @return array $product The array of WooCommerce Product data.
+	 */
+	public function event_product_create_simple( $inputs, $event ) {
+
+		// Init default Simple Product.
+		$params = [
+			'name' => $event['title'],
+			'description' => ! empty( $event['description'] ) ? $event['description'] : '',
+			'status' => 'publish',
+			'type' => 'simple',
+			'virtual' => true,
+			'downloadable' => false,
+			//'catalog_visibility' => 'hidden',
+		];
+
+		// Init Product meta data.
+		$params['meta_data'] = [];
+
+		// Add CiviCRM Entity.
+		$params['meta_data'][] = [
+			'key' => WPCV_WCI()->products->entity_key,
+			'value' => 'civicrm_participant',
+		];
+
+		// Add Financial Type ID.
+		$params['meta_data'][] = [
+			'key' => WPCV_WCI()->products->financial_type_key,
+			'value' => $inputs['financial_type_id'],
+		];
+
+		// Get the Price Field Value ID and add to metadata.
+		$pfv_id = array_pop( $inputs['pfv_ids'] );
+		$params['meta_data'][] = [
+			'key' => WPCV_WCI()->participant->pfv_key,
+			'value' => $pfv_id,
+		];
+
+		// Add Event ID.
+		$params['meta_data'][] = [
+			'key' => WPCV_WCI()->participant->event_key,
+			'value' => $inputs['event_id'],
+		];
+
+		// Add Participant Role ID.
+		$params['meta_data'][] = [
+			'key' => WPCV_WCI()->participant->role_key,
+			'value' => $inputs['role_id'],
+		];
+
+		// Get the full Price Field Value.
+		$pfv = WPCV_WCI()->helper->get_price_field_value_by_id( $pfv_id );
+
+		if ( empty( $pfv ) ) {
+			$data['notice'] = __( 'Unrecognised Price Field Value.', 'wpcv-woo-civi-integration' );
+			wp_send_json( $data );
+		}
+
+		// Set the Price.
+		$params['regular_price'] = (float) $pfv['amount'];
+
+		// Append to the Product title.
+		$params['name'] = sprintf(
+			/* translators: %1$s: Event Title, %2$s: Price Field Value label */
+			__( '%1$s (%2$s)', 'wpcv-woo-civi-integration' ), $params['name'], $pfv['label']
+		);
+
+		// Create the Participant Product.
+		$product = WPCV_WCI()->products->create_product( $params );
+
+		return $product;
+
+	}
+
+	/**
+	 * Creates a new CiviCRM Participant Product.
+	 *
+	 * @since 3.0
+	 *
+	 * @param array $inputs The validated POST data.
+	 * @param array $event The array of CiviCRM Event data.
+	 * @return array $product The array of WooCommerce Product data.
+	 */
+	public function event_product_create_custom( $inputs, $event ) {
+
+		// Init default Custom Product.
+		$params = [
+			'name' => $event['title'],
+			'description' => ! empty( $event['description'] ) ? $event['description'] : '',
+			'status' => 'publish',
+			'type' => 'civicrm_participant',
+			'virtual' => true,
+			'downloadable' => false,
+			//'catalog_visibility' => 'hidden',
+		];
+
+		// Declare CiviCRM Entity.
+		$entity = 'civicrm_participant';
+
+		// Init Product meta data.
+		$params['meta_data'] = [];
+
+		// Add Financial Type ID.
+		$params['meta_data'][] = [
+			'key' => WPCV_WCI()->products_custom->get_meta_key( $entity, 'financial_type_id' ),
+			'value' => $inputs['financial_type_id'],
+		];
+
+		// Get the Price Field Value ID and add to metadata.
+		$pfv_id = array_pop( $inputs['pfv_ids'] );
+		$params['meta_data'][] = [
+			'key' => WPCV_WCI()->products_custom->get_meta_key( $entity, 'pfv_id' ),
+			'value' => $pfv_id,
+		];
+
+		// Add Event ID.
+		$params['meta_data'][] = [
+			'key' => WPCV_WCI()->products_custom->get_meta_key( $entity, 'event_id' ),
+			'value' => $inputs['event_id'],
+		];
+
+		// Add Participant Role ID.
+		$params['meta_data'][] = [
+			'key' => WPCV_WCI()->products_custom->get_meta_key( $entity, 'role_id' ),
+			'value' => $inputs['role_id'],
+		];
+
+		// Get the full Price Field Value.
+		$pfv = WPCV_WCI()->helper->get_price_field_value_by_id( $pfv_id );
+
+		if ( empty( $pfv ) ) {
+			$data['notice'] = __( 'Unrecognised Price Field Value.', 'wpcv-woo-civi-integration' );
+			wp_send_json( $data );
+		}
+
+		// Set the Price.
+		$params['regular_price'] = (float) $pfv['amount'];
+
+		// Append to the Product title.
+		$params['name'] = sprintf(
+			/* translators: %1$s: Event Title, %2$s: Price Field Value label */
+			__( '%1$s (%2$s)', 'wpcv-woo-civi-integration' ), $params['name'], $pfv['label']
+		);
+
+		// Create the Participant Product.
+		$product = WPCV_WCI()->products->create_product( $params );
+
+		return $product;
+
+	}
+
+	/**
+	 * Creates a new Variable Product.
+	 *
+	 * @since 3.0
+	 *
+	 * @param array $inputs The validated POST data.
+	 * @param array $event The array of CiviCRM Event data.
+	 * @return array $product The array of WooCommerce Product data.
+	 */
+	public function event_product_create_variable( $inputs, $event ) {
+
+		// Init default Product.
+		$params = [
+			'name' => $event['title'],
+			'description' => ! empty( $event['description'] ) ? $event['description'] : '',
+			'status' => 'publish',
+			'type' => 'variable',
+			'virtual' => true,
+			'downloadable' => false,
+			//'catalog_visibility' => 'hidden',
+		];
+
+		// Get Price Field data.
+		$price_field_data = [];
+		foreach ( $inputs['pfv_ids'] as $pfv_id ) {
+			$price_field = WPCV_WCI()->helper->get_price_field_by_price_field_value_id( $pfv_id );
+			if ( ! empty( $price_field ) ) {
+				$price_field_data = $price_field;
+				break;
+			}
+		}
+
+		// Bail if there is no Price Field.
+		if ( empty( $price_field_data ) ) {
+			$data['notice'] = __( 'Unrecognised Price Field.', 'wpcv-woo-civi-integration' );
+			wp_send_json( $data );
+		}
+
+		// Init Price Field Attributes.
+		$pfv_attributes = [
+			'name' => $price_field_data['label'],
+			'position' => 0,
+			'visible' => true,
+			'variation' => true,
+			'options' => [],
+		];
+
+		// Build Attribute options.
+		foreach ( $inputs['pfv_ids'] as $pfv_id ) {
+
+			// Get the full Price Field Value.
+			$pfv = WPCV_WCI()->helper->get_price_field_value_by_id( $pfv_id );
+			if ( empty( $pfv ) ) {
+				continue;
+			}
+
+			// Add the Price Field Value as the slug.
+			$pfv_attributes['options'][] = $pfv['label'];
+
+		}
+
+		// Add as Product Attributes.
+		$params['attributes'] = [
+			$pfv_attributes,
+		];
+
+		// Init Product meta data.
+		$params['meta_data'] = [];
+
+		// Add CiviCRM Entity to Product metadata.
+		$params['meta_data'][] = [
+			'key' => WPCV_WCI()->products_variable->entity_key,
+			'value' => 'civicrm_participant',
+		];
+
+		// Create the Variable Product.
+		$product = WPCV_WCI()->products->create_product( $params );
+
+		// Init Menu Order.
+		$menu_order = 0;
+
+		// Set CiviCRM Entity.
+		$entity = 'civicrm_participant';
+
+		// Create the Variations.
+		foreach ( $inputs['pfv_ids'] as $pfv_id ) {
+
+			// Get the full Price Field Value.
+			$pfv = WPCV_WCI()->helper->get_price_field_value_by_id( $pfv_id );
+			if ( empty( $pfv ) ) {
+				continue;
+			}
+
+			// Init default Product Variation.
+			$variant = [
+				/* translators: %1$s: Event Title, %2$s: Price Field Value label */
+				'title' => sprintf( __( '%1$s (%2$s)', 'wpcv-woo-civi-integration' ), $event['title'], $pfv['label'] ),
+				'product_id' => $product['id'],
+				'regular_price' => (float) $pfv['amount'],
+				'menu_order' => $menu_order,
+				'virtual' => true,
+				'downloadable' => false,
+			];
+
+			// Build Variation Attributes.
+			$attributes = [];
+			$attributes[] = [
+				'name' => $pfv_attributes['name'],
+				'option' => $pfv['label'],
+			];
+
+			// Assign Variation Attributes.
+			$variant['attributes'] = $attributes;
+
+			// Init Product Variation meta data.
+			$variant['meta_data'] = [];
+
+
+			// Add Financial Type ID.
+			$variant['meta_data'][] = [
+				'key' => WPCV_WCI()->products_variable->get_meta_key( $entity, 'financial_type_id' ),
+				'value' => $inputs['financial_type_id'],
+			];
+
+			// Add Price Field Value ID.
+			$variant['meta_data'][] = [
+				'key' => WPCV_WCI()->products_variable->get_meta_key( $entity, 'pfv_id' ),
+				'value' => $pfv_id,
+			];
+
+			// Add Event ID.
+			$variant['meta_data'][] = [
+				'key' => WPCV_WCI()->products_variable->get_meta_key( $entity, 'event_id' ),
+				'value' => $inputs['event_id'],
+			];
+			// Add Participant Role ID.
+			$variant['meta_data'][] = [
+				'key' => WPCV_WCI()->products_variable->get_meta_key( $entity, 'role_id' ),
+				'value' => $inputs['role_id'],
+			];
+
+			// Create the Product Variation.
+			$variation = WPCV_WCI()->products->create_variation( $variant );
+
+			// Bump Menu Order.
+			$menu_order++;
+
+		}
+
+		return $product;
+
+	}
+
+}

--- a/includes/classes/class-woo-civi-contact-orders-tab.php
+++ b/includes/classes/class-woo-civi-contact-orders-tab.php
@@ -111,66 +111,8 @@ class WPCV_Woo_Civi_Contact_Orders_Tab {
 	 */
 	public function register_hooks() {
 
-		// Register custom PHP directory.
-		add_action( 'civicrm_config', [ $this, 'register_custom_php_directory' ], 10, 1 );
-		// Register custom template directory.
-		add_action( 'civicrm_config', [ $this, 'register_custom_template_directory' ], 10, 1 );
-		// Register menu callback.
-		add_filter( 'civicrm_xmlMenu', [ $this, 'register_callback' ], 10, 1 );
 		// Add CiviCRM settings tab.
 		add_filter( 'civicrm_tabset', [ $this, 'add_orders_contact_tab' ], 10, 3 );
-
-	}
-
-	/**
-	 * Register PHP directory.
-	 *
-	 * @since 2.0
-	 *
-	 * @param object $config The CiviCRM config object.
-	 */
-	public function register_custom_php_directory( &$config ) {
-
-		$this->fix_site();
-		$custom_path = WPCV_WOO_CIVI_PATH . 'assets/civicrm/custom_php';
-		$include_path = $custom_path . PATH_SEPARATOR . get_include_path();
-		// phpcs:ignore
-		set_include_path( $include_path );
-		$this->unfix_site();
-
-	}
-
-	/**
-	 * Register template directory.
-	 *
-	 * @since 2.0
-	 *
-	 * @param object $config The CiviCRM config object.
-	 */
-	public function register_custom_template_directory( &$config ) {
-
-		$this->fix_site();
-		$custom_path = WPCV_WOO_CIVI_PATH . 'assets/civicrm/custom_tpl';
-		$template = CRM_Core_Smarty::singleton()->addTemplateDir( $custom_path );
-		$include_template_path = $custom_path . PATH_SEPARATOR . get_include_path();
-		// phpcs:ignore
-		set_include_path( $include_template_path );
-		$this->unfix_site();
-
-	}
-
-	/**
-	 * Register XML file.
-	 *
-	 * @since 2.0
-	 *
-	 * @param array $files The array for files used to build the menu.
-	 */
-	public function register_callback( &$files ) {
-
-		$this->fix_site();
-		$files[] = WPCV_WOO_CIVI_PATH . 'assets/civicrm/xml/menu.xml';
-		$this->unfix_site();
 
 	}
 

--- a/includes/classes/class-woo-civi-contribution.php
+++ b/includes/classes/class-woo-civi-contribution.php
@@ -873,9 +873,9 @@ class WPCV_Woo_Civi_Contribution {
 		 * @param array $contribution The CiviCRM Contribution data.
 		 * @param int $order_id The WooCommerce Order ID.
 		 * @param object $order The WooCommerce Order object.
-		 * @param string $new_status The new status.
+		 * @param string $new_status_id The numeric ID of the new Status.
 		 */
-		do_action( 'wpcv_woo_civi/contribution/status_update', $contribution, $order );
+		do_action( 'wpcv_woo_civi/contribution/status_update', $contribution, $order_id, $order, $new_status_id );
 
 		// Success.
 		return $contribution;

--- a/includes/classes/class-woo-civi-contribution.php
+++ b/includes/classes/class-woo-civi-contribution.php
@@ -19,6 +19,17 @@ defined( 'ABSPATH' ) || exit;
 class WPCV_Woo_Civi_Contribution {
 
 	/**
+	 * CiviCRM Contribution component status.
+	 *
+	 * True if the CiviContribute component is active, false by default.
+	 *
+	 * @since 3.0
+	 * @access public
+	 * @var array $active The status of the CiviContribute component.
+	 */
+	public $active = false;
+
+	/**
 	 * WooCommerce Order meta key holding the CiviCRM Contribution ID.
 	 *
 	 * @since 3.0
@@ -45,7 +56,15 @@ class WPCV_Woo_Civi_Contribution {
 	 * @since 3.0
 	 */
 	public function initialise() {
+
+		// Bail early if the CiviContribute component is not active.
+		$this->active = WPCV_WCI()->helper->is_component_enabled( 'CiviContribute' );
+		if ( ! $this->active ) {
+			return;
+		}
+
 		$this->register_hooks();
+
 	}
 
 	/**

--- a/includes/classes/class-woo-civi-helper.php
+++ b/includes/classes/class-woo-civi-helper.php
@@ -764,6 +764,37 @@ class WPCV_Woo_Civi_Helper {
 	}
 
 	/**
+	 * Gets the WooCommerce Product Types as options.
+	 *
+	 * @since 3.0
+	 *
+	 * @param bool $raw Pass true if all Product Types are required.
+	 * @return array $gateways The array of WooCommerce Product Types.
+	 */
+	public function get_product_types_options( $raw = true ) {
+
+		$all_product_types = wc_get_product_types();
+
+		/**
+		 * Filter the WooCommerce Product Types.
+		 *
+		 * Used internally by:
+		 *
+		 * * WPCV_Woo_Civi_Products::product_types_filter() (Priority: 10)
+		 * * WPCV_Woo_Civi_Products_Variable::product_types_filter() (Priority: 20)
+		 * * WPCV_Woo_Civi_Products_Custom::product_types_filter() (Priority: 30)
+		 *
+		 * @since 3.0
+		 *
+		 * @param array $all_product_types The array of all WooCommerce Product Types.
+		 */
+		$all_product_types = apply_filters( 'wpcv_woo_civi/product_types/get/options', $all_product_types );
+
+		return $all_product_types;
+
+	}
+
+	/**
 	 * Gets the WooCommerce Payment Gateways.
 	 *
 	 * @since 3.0

--- a/includes/classes/class-woo-civi-order.php
+++ b/includes/classes/class-woo-civi-order.php
@@ -246,7 +246,7 @@ class WPCV_Woo_Civi_Order {
 			WPCV_WCI()->contribution->payment_create( $order_id, $order );
 		} else {
 			// No - just set the status of the Contribution.
-			WPCV_WCI()->contribution->status_update( $order_id, $new_status_id );
+			WPCV_WCI()->contribution->status_update( $order_id, $order, $new_status_id );
 		}
 
 	}

--- a/includes/classes/class-woo-civi-products-variable.php
+++ b/includes/classes/class-woo-civi-products-variable.php
@@ -1,0 +1,885 @@
+<?php
+/**
+ * Variable Products class.
+ *
+ * Handles functionality for the WooCommerce the Variable Product Type.
+ *
+ * @package WPCV_Woo_Civi
+ * @since 3.0
+ */
+
+// Exit if accessed directly.
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * Variable Products class.
+ *
+ * @since 3.0
+ */
+class WPCV_Woo_Civi_Products_Variable {
+
+	/**
+	 * WooCommerce Product meta key holding the CiviCRM Entity Type.
+	 *
+	 * @since 3.0
+	 * @access public
+	 * @var str $entity_key The CiviCRM Entity Type meta key.
+	 */
+	public $entity_key = '_wpcv_wci_variable_civicrm_entity_type';
+
+	/**
+	 * WooCommerce Product Variation meta keys.
+	 *
+	 * @since 3.0
+	 * @access public
+	 * @var array $product_variation_meta The WooCommerce Product Variation meta keys.
+	 */
+	public $product_variation_meta = [
+		'civicrm_contribution' => [
+			'financial_type_id' => '_wpcv_wci_variable_contribution_financial_type_id',
+			'pfv_id' => '_wpcv_wci_variable_contribution_pfv_id',
+		],
+		'civicrm_membership' => [
+			'financial_type_id' => '_wpcv_wci_variable_membership_financial_type_id',
+			'pfv_id' => '_wpcv_wci_variable_membership_pfv_id',
+			'type_id' => '_wpcv_wci_variable_membership_type_id',
+		],
+		'civicrm_participant' => [
+			'financial_type_id' => '_wpcv_wci_variable_participant_financial_type_id',
+			'pfv_id' => '_wpcv_wci_variable_participant_pfv_id',
+			'event_id' => '_wpcv_wci_variable_participant_event_id',
+			'role_id' => '_wpcv_wci_variable_participant_role_id',
+		],
+	];
+
+	/**
+	 * Class constructor.
+	 *
+	 * @since 3.0
+	 */
+	public function __construct() {
+
+		// Init when this plugin is fully loaded.
+		add_action( 'wpcv_woo_civi/loaded', [ $this, 'initialise' ] );
+
+	}
+
+	/**
+	 * Initialise this object.
+	 *
+	 * @since 3.0
+	 */
+	public function initialise() {
+
+		// Register hooks.
+		$this->register_hooks();
+
+	}
+
+	/**
+	 * Register hooks.
+	 *
+	 * @since 3.0
+	 */
+	private function register_hooks() {
+
+		// Add CiviCRM tab to the Variable Product Settings tabs.
+		add_filter( 'woocommerce_product_data_tabs', [ $this, 'tab_add' ], 10 );
+
+		// Add CiviCRM Variable Product panel template.
+		add_action( 'woocommerce_product_data_panels', [ $this, 'panel_add' ], 10 );
+
+		// Save metadata from the Variable Product "CiviCRM Settings" Tab.
+		add_action( 'woocommerce_admin_process_product_object', [ $this, 'panel_saved' ], 30 );
+
+		// Clear meta data from the "CiviCRM Settings" Product Tab.
+		add_action( 'wpcv_woo_civi/product/panel/saved/before', [ $this, 'panel_clear_meta' ], 40 );
+		add_action( 'wpcv_woo_civi/product/custom/panel/saved/before', [ $this, 'panel_clear_meta' ], 40 );
+
+		// Determine if the Line Item should be skipped.
+		add_filter( 'wpcv_woo_civi/products/line_item/skip', [ $this, 'line_item_skip' ], 40, 5 );
+
+		// Filter the Line Item.
+		add_filter( 'wpcv_woo_civi/products/line_item', [ $this, 'line_item_filter' ], 40, 5 );
+
+		// Get the Entity Type of a Variable Product Type.
+		add_filter( 'wpcv_woo_civi/product/query/entity_type', [ $this, 'entity_type_get' ], 20, 3 );
+
+		// Save the Entity Type of a Variable Product Type.
+		add_action( 'wpcv_woo_civi/product/save/entity_type', [ $this, 'entity_type_save' ], 20, 2 );
+
+		// Get the Financial Type ID of a Product Variation.
+		//add_filter( 'wpcv_woo_civi/product/query/financial_type_id', [ $this, 'financial_type_id_get' ], 20, 3 );
+
+		// Save the Financial Type ID of a Product Variation.
+		//add_action( 'wpcv_woo_civi/product/save/financial_type_id', [ $this, 'financial_type_id_save' ], 20, 2 );
+
+		// Filter the Product Type options to exclude Variable Product Type.
+		add_filter( 'wpcv_woo_civi/product_types/get/options', [ $this, 'product_types_filter' ], 20 );
+
+		// Add CiviCRM Product Variation template.
+		add_action( 'woocommerce_product_after_variable_attributes', [ $this, 'variation_attributes_render' ], 10, 3 );
+
+		// Add metadata to the Product Variation before it is saved.
+		//add_action( 'woocommerce_admin_process_variation_object', [ $this, 'variation_attributes_add' ], 10, 2 );
+
+	}
+
+	/**
+	 * Adds a "CiviCRM Settings" Product Tab to the New & Edit Product screens.
+	 *
+	 * @since 3.0
+	 *
+	 * @param array $tabs The existing Product tabs.
+	 * @return array $tabs The modified Product tabs.
+	 */
+	public function tab_add( $tabs ) {
+
+		$tabs['civicrm_variable'] = [
+			'label' => __( 'CiviCRM Settings', 'wpcv-woo-civi-integration' ),
+			'target' => 'civicrm_variable',
+			'class' => [
+				'show_if_variable',
+			],
+		];
+
+		return $tabs;
+
+	}
+
+	/**
+	 * Includes the CiviCRM Settings panels on the New & Edit Product screens.
+	 *
+	 * @since 3.0
+	 */
+	public function panel_add() {
+
+		global $thepostid, $post;
+
+		// Try and get the ID of the Product.
+		$product_id = empty( $thepostid ) ? $post->ID : $thepostid;
+
+		// Build options for the the Entities select.
+		$entity_options = WPCV_WCI()->helper->get_entity_type_options();
+
+		// Include template.
+		$directory = 'assets/templates/woocommerce/admin/meta-boxes/views/';
+		include WPCV_WOO_CIVI_PATH . $directory . 'html-product-data-panel-variable.php';
+
+	}
+
+	/**
+	 * Adds the CiviCRM Settings as meta to the Product.
+	 *
+	 * @since 3.0
+	 *
+	 * @param WC_Product $product The Product object.
+	 */
+	public function panel_saved( $product ) {
+
+		// Bail if not a Variable Product Type.
+		$product_type = $product->get_type();
+		if ( 'variable' !== $product->get_type() ) {
+			return;
+		}
+
+		/**
+		 * Fires before the settings from the Variable Product "CiviCRM Settings" Tab have been saved.
+		 *
+		 * Used internally by:
+		 *
+		 * * WPCV_Woo_Civi_Settings_Products::panel_clear_meta() (Priority: 10)
+		 * * WPCV_Woo_Civi_Membership::panel_clear_meta() (Priority: 20)
+		 * * WPCV_Woo_Civi_Participant::panel_clear_meta() (Priority: 30)
+		 * * WPCV_Woo_Civi_Products_Custom::panel_clear_meta() (Priority: 50)
+		 *
+		 * @since 3.0
+		 *
+		 * @param WC_Product $product The Product object.
+		 */
+		do_action( 'wpcv_woo_civi/product/variable/panel/saved/before', $product );
+
+		// Save the Entity Type.
+		if ( isset( $_POST[ $this->entity_key ] ) ) {
+			$entity_type = sanitize_key( $_POST[ $this->entity_key ] );
+			$product->add_meta_data( $this->entity_key, $entity_type, true );
+		}
+
+		/**
+		 * Fires after the settings from the Variable Product "CiviCRM Settings" Tab have been saved.
+		 *
+		 * @since 3.0
+		 *
+		 * @param WC_Product $product The Product object.
+		 */
+		do_action( 'wpcv_woo_civi/product/variable/panel/saved/after', $product );
+
+	}
+
+	/**
+	 * Clears the metadata for this Variable Product.
+	 *
+	 * @since 3.0
+	 *
+	 * @param WC_Product $product The Product object.
+	 */
+	public function panel_clear_meta( $product ) {
+
+		// Clear the current Variable Product metadata.
+		$product->delete_meta_data( $this->entity_key );
+
+		// TODO: What happens to Product Variations when the Product Type is switched?
+
+	}
+
+	/**
+	 * Renders the CiviCRM Settings on the Product Variation.
+	 *
+	 * Not built yet.
+	 *
+	 * @since 3.0
+	 *
+	 * @param int $loop The position in the loop.
+	 * @param array $variation_data The Variation data.
+	 * @param WP_Post $variation The WordPress Post data.
+	 */
+	public function variation_attributes_render( $loop, $variation_data, $variation ) {
+
+		// Get parent Variable Product.
+		$parent = wc_get_product( $variation->post_parent );
+
+		// Get parent CiviCRM Entity Type.
+		$entity = $parent->get_meta( $this->entity_key );
+
+		// Construct the Financial Type options.
+		$financial_type_options = [
+			'' => __( 'Select a Financial Type', 'wpcv-woo-civi-integration' ),
+		] + WPCV_WCI()->helper->get_financial_types();
+
+		// Get the Price Sets.
+		$price_sets = WPCV_WCI()->helper->get_price_sets_populated();
+
+		// Get common meta keys for the form elements.
+		$financial_type_id_key = $this->get_meta_key( $entity, 'financial_type_id' );
+		$pfv_id_key = $this->get_meta_key( $entity, 'pfv_id' );
+
+		// Get common metadata.
+		$financial_type_id = $this->get_meta( $variation->ID, $entity, 'financial_type_id' );
+		$pfv_id = $this->get_meta( $variation->ID, $entity, 'pfv_id' );
+
+		// Include template.
+		$directory = 'assets/templates/woocommerce/admin/meta-boxes/views/';
+		include WPCV_WOO_CIVI_PATH . $directory . 'html-product-data-panel-variation.php';
+
+	}
+
+	/**
+	 * Sets the Product Variation properties before it is saved.
+	 *
+	 * @since 3.0
+	 *
+	 * @param WC_Product_Variation $variation The Product Variation object.
+	 * @param int $loop The position in the loop.
+	 */
+	public function variation_attributes_add( $variation, $loop ) {
+
+		///*
+		$e = new \Exception();
+		$trace = $e->getTraceAsString();
+		error_log( print_r( [
+			'method' => __METHOD__,
+			'variation' => $variation,
+			'loop' => $loop,
+			//'backtrace' => $trace,
+		], true ) );
+		//*/
+
+		// Clear existing Product Variation metadata.
+		foreach ( $this->product_variation_meta as $entity => $data ) {
+			foreach ( $data as $shorthand => $meta_key ) {
+				$variation->delete_meta_data( $meta_key );
+			}
+		}
+
+		// Get CiviCRM Entity Type.
+		$entity_type = $this->entity_type_get_from_parent( $product );
+
+		// Bail there isn't one or it's excluded from sync.
+		if ( empty( $entity_type ) || $entity_type === 'civicrm_exclude' ) {
+			return;
+		}
+
+		// Get meta keys.
+		$financial_type_key = $this->get_meta_key( $entity_type, 'financial_type_id' );
+		$pfv_key = $this->get_meta_key( $entity_type, 'pfv_id' );
+
+		// Save the Financial Type.
+		if ( isset( $_POST[ $financial_type_key ] ) ) {
+			$value = sanitize_key( $financial_type_key );
+			$variation->add_meta_data( $financial_type_key, $value, true );
+		}
+
+		// Save the Price Field Value.
+		if ( isset( $_POST[ $pfv_key ] ) ) {
+			$value = sanitize_key( $pfv_key );
+			$variation->add_meta_data( $pfv_key, $value, true );
+		}
+
+		/**
+		 * Fires when the Product Variation properties have been saved.
+		 *
+		 * Used internally by:
+		 *
+		 * * WPCV_Woo_Civi_Membership::variation_attributes_save() (Priority: 10)
+		 * * WPCV_Woo_Civi_Participant::variation_attributes_save() (Priority: 20)
+		 *
+		 * @since 3.0
+		 *
+		 * @param WC_Product $product The Product object.
+		 */
+		do_action( 'wpcv_woo_civi/product/variation/attributes/added', $product );
+
+	}
+
+	/**
+	 * Determines if a Line Item should be skipped.
+	 *
+	 * @since 3.0
+	 *
+	 * @param bool $skip The possibly set "skip" flag.
+	 * @param object $item The WooCommerce Item object.
+	 * @param object $product The WooCommerce Product object.
+	 * @param string $product_type The WooCommerce Product Type.
+	 * @param string $entity The mapped CiviCRM Entity.
+	 * @return bool $skip The determined "skip" flag.
+	 */
+	public function line_item_skip( $skip, $item, $product, $product_type, $entity ) {
+
+		// Exclude when empty or when specified.
+		if ( '' === $entity || 'civicrm_exclude' === $entity ) {
+			$skip = true;
+		}
+
+		return $skip;
+
+	}
+
+	/**
+	 * Filters a Line Item to create an Entity that matches the Product Variation.
+	 *
+	 * @since 3.0
+	 *
+	 * @param array $line_item The array of Line Item data.
+	 * @param object $item The WooCommerce Item object.
+	 * @param object $product The WooCommerce Product object.
+	 * @param object $order The WooCommerce Order object.
+	 * @param array $params The params to be passed to the CiviCRM API.
+	 * @return array $line_item The modified array of Line Item data.
+	 */
+	public function line_item_filter( $line_item, $item, $product, $order, $params ) {
+
+		// Bail if not a Product Variation.
+		$product_type = $product->get_type();
+		if ( $product_type !== 'variation' ) {
+			return $line_item;
+		}
+
+		// Get the mapped CiviCRM Entity.
+		$entity_type = $this->entity_type_get_from_parent( $product );
+
+		// Send to relevant method.
+		switch ( $entity_type ) {
+			case 'civicrm_contribution' :
+				$line_item = $this->line_item_contribution_filter( $line_item, $item, $product, $order, $params );
+				break;
+			case 'civicrm_membership' :
+				$line_item = $this->line_item_membership_filter( $line_item, $item, $product, $order, $params );
+				break;
+			case 'civicrm_participant' :
+				$line_item = $this->line_item_participant_filter( $line_item, $item, $product, $order, $params );
+				break;
+		}
+
+		return $line_item;
+
+	}
+
+	/**
+	 * Filters a Line Item to add a Contribution.
+	 *
+	 * @since 3.0
+	 *
+	 * @param array $line_item The array of Line Item data.
+	 * @param object $item The WooCommerce Item object.
+	 * @param object $product The WooCommerce Product object.
+	 * @param object $order The WooCommerce Order object.
+	 * @param array $params The params to be passed to the CiviCRM API.
+	 * @return array $line_item The modified array of Line Item data.
+	 */
+	public function line_item_contribution_filter( $line_item, $item, $product, $order, $params ) {
+
+		// Define the Product Type name.
+		$entity_type = 'civicrm_contribution';
+
+		// Get the Product ID.
+		$product_id = $product->get_id();
+
+		// Get Financial Type ID from Product meta.
+		$financial_type_id = $this->get_meta( $product_id, $entity_type, 'financial_type_id' );
+		if ( empty( $financial_type_id ) ) {
+			return $line_item;
+		}
+
+		// Get Price Field Value ID from Product meta.
+		$price_field_value_id = $this->get_meta( $product_id, $entity_type, 'pfv_id' );
+		if ( empty( $price_field_value_id ) ) {
+			return $line_item;
+		}
+
+		// Get Price Field Value data.
+		$price_field_value = WPCV_WCI()->helper->get_price_field_value_by_id( $price_field_value_id );
+		if ( empty( $price_field_value ) ) {
+			return $line_item;
+		}
+
+		// Get Price Field data.
+		$price_field = WPCV_WCI()->helper->get_price_field_by_price_field_value_id( $price_field_value_id );
+		if ( empty( $price_field ) ) {
+			return $line_item;
+		}
+
+		// Grab the existing Line Item data.
+		$line_item_data = array_pop( $line_item['line_item'] );
+
+		// TODO: Are there other params for the Line Item data?
+		$contribution_line_item_data = [
+			'financial_type_id' => $financial_type_id,
+			'price_field_id' => $price_field_value['price_field_id'],
+			'price_field_value_id' => $price_field_value_id,
+			'label' => $price_field_value['label'],
+		];
+
+		// TODO: Look at the Line Item.
+		$line_item_params = [];
+
+		// Apply Contribution to Line Item.
+		$line_item = [
+			'params' => $line_item_params,
+			'line_item' => [
+				array_merge( $line_item_data, $contribution_line_item_data ),
+			],
+		];
+
+		return $line_item;
+
+	}
+
+	/**
+	 * Filters a Line Item to add a Membership.
+	 *
+	 * This method is a modified clone of the global Membership Line Item filter
+	 * except that the source of the data is the Product Variation.
+	 *
+	 * @see WPCV_Woo_Civi_Membership::line_item_filter()
+	 *
+	 * @since 3.0
+	 *
+	 * @param array $line_item The array of Line Item data.
+	 * @param object $item The WooCommerce Item object.
+	 * @param object $product The WooCommerce Product object.
+	 * @param object $order The WooCommerce Order object.
+	 * @param array $params The params to be passed to the CiviCRM API.
+	 * @return array $line_item The modified array of Line Item data.
+	 */
+	public function line_item_membership_filter( $line_item, $item, $product, $order, $params ) {
+
+		// Bail if CiviMember isn't active.
+		if ( ! WPCV_WCI()->membership->active ) {
+			return $line_item;
+		}
+
+		// Define the Product Type name.
+		$entity_type = 'civicrm_membership';
+
+		// Get the Product ID.
+		$product_id = $product->get_id();
+
+		// Get Financial Type ID from Product meta.
+		$financial_type_id = $this->get_meta( $product_id, $entity_type, 'financial_type_id' );
+		if ( empty( $financial_type_id ) ) {
+			return $line_item;
+		}
+
+		// Get Membership Type ID from Product meta.
+		$membership_type_id = $this->get_meta( $product_id, $entity_type, 'type_id' );
+		if ( empty( $membership_type_id ) ) {
+			return $line_item;
+		}
+
+		// Get Price Field Value ID from Product meta.
+		$price_field_value_id = $this->get_meta( $product_id, $entity_type, 'pfv_id' );
+		if ( empty( $price_field_value_id ) ) {
+			return $line_item;
+		}
+
+		// Make an array of the params.
+		$args = [
+			'item' => $item,
+			'product' => $product,
+			'order' => $order,
+			'params' => $params,
+			'financial_type_id' => $financial_type_id,
+			'membership_type_id' => $membership_type_id,
+			'price_field_value_id' => $price_field_value_id,
+		];
+
+		// Populate the Line Item.
+		$line_item = WPCV_WCI()->membership->line_item_populate( $line_item, $args );
+
+		return $line_item;
+
+	}
+
+	/**
+	 * Filters a Line Item to create an Event Participant.
+	 *
+	 * This method is a modified clone of the global Participant Line Item filter
+	 * except that the source of the data is the Product Variation.
+	 *
+	 * @see WPCV_Woo_Civi_Participant::line_item_filter()
+	 *
+	 * @since 3.0
+	 *
+	 * @param array $line_item The array of Line Item data.
+	 * @param object $item The WooCommerce Item object.
+	 * @param object $product The WooCommerce Product object.
+	 * @param object $order The WooCommerce Order object.
+	 * @param array $params The params to be passed to the CiviCRM API.
+	 * @return array $line_item The modified array of Line Item data.
+	 */
+	public function line_item_participant_filter( $line_item, $item, $product, $order, $params ) {
+
+		// Bail if CiviEvent isn't active.
+		if ( ! WPCV_WCI()->participant->active ) {
+			return $line_item;
+		}
+
+		// Define the Entity Type.
+		$entity_type = 'civicrm_participant';
+
+		// Get the Product ID.
+		$product_id = $product->get_id();
+
+		// Get Financial Type ID from Product meta.
+		$financial_type_id = $this->get_meta( $product_id, $entity_type, 'financial_type_id' );
+		if ( empty( $financial_type_id ) ) {
+			return $line_item;
+		}
+
+		// Get Event ID from Product meta.
+		$event_id = $this->get_meta( $product_id, $entity_type, 'event_id' );
+		if ( empty( $event_id ) ) {
+			return $line_item;
+		}
+
+		// Get Participant Role ID from Product meta.
+		$participant_role_id = $this->get_meta( $product_id, $entity_type, 'role_id' );
+		if ( empty( $participant_role_id ) ) {
+			return $line_item;
+		}
+
+		// Get Price Field Value ID from Product meta.
+		$price_field_value_id = $this->get_meta( $product_id, $entity_type, 'pfv_id' );
+		if ( empty( $price_field_value_id ) ) {
+			return $line_item;
+		}
+
+		// Make an array of the params.
+		$args = [
+			'item' => $item,
+			'product' => $product,
+			'order' => $order,
+			'params' => $params,
+			'financial_type_id' => $financial_type_id,
+			'event_id' => $event_id,
+			'participant_role_id' => $participant_role_id,
+			'price_field_value_id' => $price_field_value_id,
+		];
+
+		// Populate the Line Item.
+		$line_item = WPCV_WCI()->participant->line_item_populate( $line_item, $args );
+
+		return $line_item;
+
+	}
+
+	/**
+	 * Gets the requested meta key for the Product Variation.
+	 *
+	 * This method does not check for the existence of an entry in the array
+	 * because it needs to be called correctly and will produce log entries
+	 * when it is not.
+	 *
+	 * @since 3.0
+	 *
+	 * @param str $type The type of Product Variation.
+	 * @param str $key The shorthand for the meta key.
+	 * @return str The requested meta key.
+	 */
+	public function get_meta_key( $type, $key ) {
+		return $this->product_variation_meta[ $type ][ $key ];
+	}
+
+	/**
+	 * Gets the metadata from Product Variation meta.
+	 *
+	 * @since 3.0
+	 *
+	 * @param int $product_id The Product ID.
+	 * @param str $type The type of Product Variation.
+	 * @param str $key The name of the meta key.
+	 * @return mixed $value The value, false otherwise.
+	 */
+	public function get_meta( $product_id, $type, $key ) {
+		$value = false;
+		if ( ! empty( $this->product_variation_meta[ $type ][ $key ] ) ) {
+			$value = get_post_meta( $product_id, $this->product_variation_meta[ $type ][ $key ], true );
+		}
+		return $value;
+	}
+
+	/**
+	 * Sets the metadata on a Product Variation.
+	 *
+	 * @since 3.0
+	 *
+	 * @param int $product_id The Product ID.
+	 * @param str $type The type of Product Variation.
+	 * @param str $key The name of the meta key.
+	 * @param mixed $value The value to save.
+	 */
+	public function set_meta( $product_id, $type, $key, $value ) {
+		if ( ! empty( $this->product_variation_meta[ $type ][ $key ] ) ) {
+			update_post_meta( $product_id, $this->product_variation_meta[ $type ][ $key ], $value );
+		}
+	}
+
+	/**
+	 * Gets the Entity Type from the parent Product of a Product Variation.
+	 *
+	 * @since 3.0
+	 *
+	 * @param object $product The WooCommerce Product object.
+	 * @return string $entity_type The found Entity Type, empty otherwise.
+	 */
+	public function entity_type_get_from_parent( $product ) {
+
+		// Init return.
+		$entity_type = '';
+
+		// Bail if no Product passed in.
+		if ( empty( $product ) ) {
+			return $entity_type;
+		}
+
+		// Bail if not a Product Variation.
+		$product_type = $product->get_type();
+		if ( $product_type !== 'variation' ) {
+			return $entity_type;
+		}
+
+		// Get parent Product.
+		$parent_id = $product->get_parent_id();
+		$parent = wc_get_product( $parent_id );
+		if ( empty( $parent ) ) {
+			return $entity_type;
+		}
+
+		// Get the Entity Type.
+		$entity_type = $parent->get_meta( $this->entity_key );
+
+		return $entity_type;
+
+	}
+
+	/**
+	 * Gets the Entity Type from WooCommerce Product meta.
+	 *
+	 * @since 3.0
+	 *
+	 * @param str $entity_type The possibly found Entity Type.
+	 * @param int $product_id The Product ID.
+	 * @param object $product The WooCommerce Product object.
+	 * @return str $entity_type The found Entity Type, passed through otherwise.
+	 */
+	public function entity_type_get( $entity_type, $product_id, $product = null ) {
+
+		// Pass through if already found.
+		if ( $entity_type !== '' ) {
+			return $entity_type;
+		}
+
+		// Get the Product if not supplied.
+		if ( empty( $product ) ) {
+			$product = wc_get_product( $product_id );
+		}
+
+		// Pass through if Product not found.
+		if ( empty( $product ) ) {
+			return $entity_type;
+		}
+
+		// Pass through if not a Variable Product or a Product Variation.
+		$product_type = $product->get_type();
+		if ( $product_type !== 'variable' && $product_type !== 'variation' ) {
+			return $entity_type;
+		}
+
+		// Get Entity Type from meta when Variable Product.
+		if ( $product_type === 'variable' ) {
+			$entity_type = $product->get_meta( $this->entity_key );
+		}
+
+		// Get Entity Type from parent meta when Product Variation.
+		if ( $product_type === 'variation' ) {
+			$entity_type = $this->entity_type_get_from_parent( $product );
+		}
+
+		return $entity_type;
+
+	}
+
+	/**
+	 * Saves the Entity Type to WooCommerce Product meta.
+	 *
+	 * @since 3.0
+	 *
+	 * @param object $product The WooCommerce Product object.
+	 * @param str $entity_type The CiviCRM Entity Type.
+	 */
+	public function entity_type_save( $product, $entity_type ) {
+
+		// Bail if no Product passed in.
+		if ( empty( $product ) ) {
+			return;
+		}
+
+		// Bail if not a Variable Product or a Product Variation.
+		$product_type = $product->get_type();
+		if ( $product_type !== 'variable' && $product_type !== 'variation' ) {
+			return;
+		}
+
+		// Save Entity Type to meta.
+		if ( $product_type === 'variable' ) {
+			$product->add_meta_data( $this->entity_key, $entity_type, true );
+			$id = $product->save();
+		}
+
+		// Get Entity Type from parent meta when Product Variation.
+		if ( $product_type === 'variation' ) {
+			$parent_id = $product->get_parent_id();
+			$parent = wc_get_product( $parent_id );
+			$parent->add_meta_data( $this->entity_key, $entity_type, true );
+			$id = $parent->save();
+		}
+
+	}
+
+	/**
+	 * Gets the Financial Type ID from WooCommerce Product meta.
+	 *
+	 * @since 3.0
+	 *
+	 * @param int $financial_type_id The possibly found Financial Type ID.
+	 * @param int $product_id The Product ID.
+	 * @param object $product The WooCommerce Product object.
+	 * @return int $financial_type_id The found Financial Type ID, passed through otherwise.
+	 */
+	public function financial_type_id_get( $financial_type_id, $product_id, $product = null ) {
+
+		// Pass through if already found.
+		if ( $financial_type_id !== 0 ) {
+			return $financial_type_id;
+		}
+
+		// Get the Product if not supplied.
+		if ( empty( $product ) ) {
+			$product = wc_get_product( $product_id );
+		}
+
+		// Pass through if Product not found.
+		if ( empty( $product ) ) {
+			return $financial_type_id;
+		}
+
+		// Pass through if not a Product Variation.
+		$product_type = $product->get_type();
+		if ( $product_type !== 'variation' ) {
+			return $entity_type;
+		}
+
+		// Get Entity Type from parent Product.
+		$entity_type = $this->entity_type_get_from_parent( $product );
+
+		// Return Financial Type ID if found.
+		$financial_type_id_key = $this->get_meta_key( $entity_type, 'financial_type_id' );
+		$product_financial_type_id = $product->get_meta( $financial_type_id_key );
+		if ( ! empty( $product_financial_type_id ) ) {
+			return $product_financial_type_id;
+		}
+
+		// Not found.
+		return 0;
+
+	}
+
+	/**
+	 * Saves the Financial Type ID to WooCommerce Product meta.
+	 *
+	 * @since 3.0
+	 *
+	 * @param object $product The WooCommerce Product object.
+	 * @param int $financial_type_id The Financial Type ID.
+	 */
+	public function financial_type_id_save( $product, $financial_type_id ) {
+
+		// Bail if no Product passed in.
+		if ( empty( $product ) ) {
+			return;
+		}
+
+		// Bail if not a Product Variation.
+		$product_type = $product->get_type();
+		if ( $product_type !== 'variation' ) {
+			return;
+		}
+
+		// Get Entity from parent Product.
+		$entity_type = $this->entity_type_get_from_parent( $product );
+
+		// Save Financial Type ID to meta.
+		$this->set_meta( $product->get_id(), $entity_type, 'financial_type_id', $financial_type_id );
+
+	}
+
+	/**
+	 * Filters the Product Type options to exclude Variable Product Type.
+	 *
+	 * @since 3.0
+	 *
+	 * @param array $product_types The existing array of WooCommerce Product Types.
+	 * @return array $product_types The modified array of WooCommerce Product Types.
+	 */
+	public function product_types_filter( $product_types ) {
+
+		// Remove Variable Product if present.
+		if ( array_key_exists( 'variable', $product_types ) ) {
+			unset( $product_types['variable'] );
+		}
+
+		return $product_types;
+
+	}
+
+}

--- a/includes/classes/class-woo-civi-products.php
+++ b/includes/classes/class-woo-civi-products.php
@@ -800,4 +800,96 @@ class WPCV_Woo_Civi_Products {
 
 	}
 
+	/**
+	 * Creates a WooCommerce Product.
+	 *
+	 * @since 3.0
+	 *
+	 * @param array $params The set of data to create the WooCommerce Product.
+	 * @return array $product The array of WooCommerce Product data, or empty on failure.
+	 */
+	public function create_product( $params ) {
+
+		// Build request.
+		$request = new WP_REST_Request( 'POST' );
+		$request->set_body_params( $params );
+
+		// Maybe initialise the Products Controller.
+		if ( ! isset( $this->products_controller ) ) {
+			$this->products_controller = new WC_REST_Products_Controller();
+		}
+
+		// Create the Product.
+		$result = $this->products_controller->create_item( $request );
+
+		// The Product data is what we want.
+		$product = isset( $result->data ) ? $result->data : false;
+
+		return $product;
+
+	}
+
+	/**
+	 * Updates a WooCommerce Product.
+	 *
+	 * @since 3.0
+	 *
+	 * @param array $params The set of data to update the WooCommerce Product.
+	 * @return array $product The array of WooCommerce Product data, or empty on failure.
+	 */
+	public function update_product( $params ) {
+
+		// Bail if there is no Product ID.
+		if ( empty( $params['id'] ) ) {
+			return false;
+		}
+
+		// Build request.
+		$request = new WP_REST_Request( 'PUT' );
+		$request->set_body_params( $params );
+
+		// Maybe initialise the Products Controller.
+		if ( ! isset( $this->products_controller ) ) {
+			$this->products_controller = new WC_REST_Products_Controller();
+		}
+
+		// Update the Product.
+		$result = $this->products_controller->update_item( $request );
+
+		// The Product data is what we want.
+		$product = isset( $result->data ) ? $result->data : false;
+
+		return $product;
+
+	}
+
+	/**
+	 * Creates a WooCommerce Product Variation.
+	 *
+	 * @since 3.0
+	 *
+	 * @param array $params The set of data to create the WooCommerce Product Variation.
+	 * @return array $variation The array of WooCommerce Product Variation data, or empty on failure.
+	 */
+	public function create_variation( $params ) {
+
+		// Build request.
+		$request = new WP_REST_Request( 'POST' );
+		$request->set_body_params( $params );
+
+		// Maybe initialise the Variations Controller.
+		if ( ! isset( $this->variations_controller ) ) {
+			$this->variations_controller = new WC_REST_Product_Variations_Controller();
+		}
+
+		// Create the Product Variation.
+		$result = $this->variations_controller->create_item( $request );
+
+		// The Product Variation data is what we want.
+		$variation = isset( $result->data ) ? $result->data : false;
+
+		return $variation;
+
+	}
+
 }

--- a/includes/classes/class-woo-civi-products.php
+++ b/includes/classes/class-woo-civi-products.php
@@ -23,7 +23,7 @@ class WPCV_Woo_Civi_Products {
 	 *
 	 * @since 3.0
 	 * @access public
-	 * @var str $meta_key The CiviCRM Entity Type meta key.
+	 * @var str $entity_key The CiviCRM Entity Type meta key.
 	 */
 	public $entity_key = '_woocommerce_civicrm_entity_type';
 
@@ -32,9 +32,9 @@ class WPCV_Woo_Civi_Products {
 	 *
 	 * @since 3.0
 	 * @access public
-	 * @var str $meta_key The CiviCRM Financial Type ID meta key.
+	 * @var str $financial_type_key The CiviCRM Financial Type ID meta key.
 	 */
-	public $meta_key = '_woocommerce_civicrm_financial_type_id';
+	public $financial_type_key = '_woocommerce_civicrm_financial_type_id';
 
 	/**
 	 * WooCommerce Product meta key holding the CiviCRM Contribution Price Field Value ID.
@@ -92,95 +92,26 @@ class WPCV_Woo_Civi_Products {
 		// Get Line Items for Payment.
 		//add_filter( 'wpcv_woo_civi/contribution/payment_create/params', [ $this, 'items_get_for_payment' ], 10, 3 );
 
-		// Get the Entity Type of a Custom Product Type.
-		add_filter( 'wpcv_woo_civi/product/query/entity_type', [ $this, 'entity_type_get' ], 20, 2 );
+		// Get the Entity Type from WooCommerce Product meta.
+		add_filter( 'wpcv_woo_civi/product/query/entity_type', [ $this, 'entity_type_get' ], 10, 3 );
+
+		// Save the Entity Type to WooCommerce Product meta.
+		add_action( 'wpcv_woo_civi/product/save/entity_type', [ $this, 'entity_type_save' ], 10, 2 );
 
 		// Get the Financial Type ID from WooCommerce Product meta.
-		add_filter( 'wpcv_woo_civi/product/query/financial_type_id', [ $this, 'financial_type_id_get' ], 10, 2 );
+		add_filter( 'wpcv_woo_civi/product/query/financial_type_id', [ $this, 'financial_type_id_get' ], 10, 3 );
+
+		// Save the Financial Type ID to WooCommerce Product meta.
+		add_action( 'wpcv_woo_civi/product/save/financial_type_id', [ $this, 'financial_type_id_save' ], 10, 2 );
 
 		// Get the Price Field Value ID from WooCommerce Product meta.
-		add_filter( 'wpcv_woo_civi/product/query/pfv_id', [ $this, 'pfv_id_get' ], 20, 2 );
+		add_filter( 'wpcv_woo_civi/product/query/pfv_id', [ $this, 'pfv_id_get' ], 10, 3 );
 
-	}
+		// Determine if the Line Item should be skipped.
+		add_filter( 'wpcv_woo_civi/products/line_item/skip', [ $this, 'line_item_skip' ], 10, 5 );
 
-	/**
-	 * Gets the Entity Type from WooCommerce Product meta.
-	 *
-	 * @since 3.0
-	 *
-	 * @param str $entity_type The possibly found Entity Type.
-	 * @param int $product_id The Product ID.
-	 * @return str $entity_type The found Entity Type, passed through otherwise.
-	 */
-	public function entity_type_get( $entity_type, $product_id ) {
-
-		// Pass through if already found.
-		if ( $entity_type !== '' ) {
-			return $entity_type;
-		}
-
-		// Return the contents of the "global" Financial Type ID if found.
-		$product_entity_type = get_post_meta( $product_id, $this->entity_key, true );
-		if ( ! empty( $product_entity_type ) ) {
-			return $product_entity_type;
-		}
-
-		// Not found.
-		return '';
-
-	}
-
-	/**
-	 * Gets the Financial Type ID from WooCommerce Product meta.
-	 *
-	 * @since 3.0
-	 *
-	 * @param int $financial_type_id The possibly found Financial Type ID.
-	 * @param int $product_id The Product ID.
-	 * @return int $financial_type_id The found Financial Type ID, passed through otherwise.
-	 */
-	public function financial_type_id_get( $financial_type_id, $product_id ) {
-
-		// Pass through if already found.
-		if ( $financial_type_id !== 0 ) {
-			return $financial_type_id;
-		}
-
-		// Return the contents of the "global" Financial Type ID if found.
-		$product_financial_type_id = get_post_meta( $product_id, $this->meta_key, true );
-		if ( ! empty( $product_financial_type_id ) ) {
-			return $product_financial_type_id;
-		}
-
-		// Not found.
-		return 0;
-
-	}
-
-	/**
-	 * Gets the Price Field Value ID from WooCommerce Product meta.
-	 *
-	 * @since 3.0
-	 *
-	 * @param int $pfv_id The possibly found Price Field Value ID.
-	 * @param int $product_id The Product ID.
-	 * @return int $pfv_id The found Price Field Value ID, passed through otherwise.
-	 */
-	public function pfv_id_get( $pfv_id, $product_id ) {
-
-		// Pass through if already found.
-		if ( $pfv_id !== 0 ) {
-			return $pfv_id;
-		}
-
-		// Return the contents of the "global" Price Field Value ID if found.
-		$product_pfv_id = get_post_meta( $product_id, $this->pfv_key, true );
-		if ( ! empty( $product_pfv_id ) ) {
-			return $product_pfv_id;
-		}
-
-		// Not found.
-		return 0;
+		// Filter the Product Type options to exclude ineligible default Product Types.
+		add_filter( 'wpcv_woo_civi/product_types/get/options', [ $this, 'product_types_filter' ], 10 );
 
 	}
 
@@ -218,7 +149,7 @@ class WPCV_Woo_Civi_Products {
 	 * @return int|bool $financial_type_id The Financial Type ID, false otherwise.
 	 */
 	public function get_product_meta( $product_id ) {
-		$financial_type_id = get_post_meta( $product_id, $this->meta_key, true );
+		$financial_type_id = get_post_meta( $product_id, $this->financial_type_key, true );
 		return $financial_type_id;
 	}
 
@@ -231,7 +162,7 @@ class WPCV_Woo_Civi_Products {
 	 * @param int $financial_type_id The numeric ID of the Financial Type.
 	 */
 	public function set_product_meta( $product_id, $financial_type_id ) {
-		update_post_meta( $product_id, $this->meta_key, $financial_type_id );
+		update_post_meta( $product_id, $this->financial_type_key, $financial_type_id );
 	}
 
 	/**
@@ -317,22 +248,13 @@ class WPCV_Woo_Civi_Products {
 		foreach ( $items as $item_id => $item ) {
 
 			$product = $item->get_product();
-			$product_type = $product->get_type();
 
-			// Skip/exclude if this Product should not be synced to CiviCRM.
-			$product_entity_type = $product->get_meta( $this->entity_key );
-			// Our Custom Product Types always sync.
-			if ( ! array_key_exists( $product_type, WPCV_WCI()->products_custom->product_types_meta ) ) {
-				if ( '' === $product_entity_type || 'civicrm_exclude' === $product_entity_type ) {
-					continue;
-				}
-			}
-
-			// Skip if this Product still has the legacy "exclude" setting.
-			$product_financial_type_id = $product->get_meta( $this->meta_key );
-			if ( 'exclude' === $product_financial_type_id ) {
+			// Skip/exclude if this Item should be excluded from a CiviCRM Order.
+			if ( $this->item_should_be_skipped( $item, $product, $order ) ) {
 				continue;
 			}
+
+			$product_financial_type_id = $product->get_meta( $this->financial_type_key );
 
 			$line_item_data = [
 				'entity_table' => 'civicrm_contribution',
@@ -387,6 +309,7 @@ class WPCV_Woo_Civi_Products {
 			 * * WPCV_Woo_Civi_Tax::line_item_tax_add() (Priority: 10)
 			 * * WPCV_Woo_Civi_Membership::line_item_filter() (Priority: 20)
 			 * * WPCV_Woo_Civi_Participant::line_item_filter() (Priority: 30)
+			 * * WPCV_Woo_Civi_Products_Variable::line_item_filter() (Priority: 40)
 			 * * WPCV_Woo_Civi_Products_Custom::line_item_filter() (Priority: 50)
 			 *
 			 * @since 3.0
@@ -444,6 +367,78 @@ class WPCV_Woo_Civi_Products {
 		}
 
 		return $params;
+
+	}
+
+	/**
+	 * Checks if an Item should be excluded from a CiviCRM Order.
+	 *
+	 * @since 3.0
+	 *
+	 * @param object $item The WooCommerce Item object.
+	 * @param object $product The WooCommerce Product object.
+	 * @param object $order The Order object.
+	 * @return bool $skip True if the Item should be skipped, false otherwise.
+	 */
+	public function item_should_be_skipped( $item, $product, $order ) {
+
+		// Always skip if this Product still has the legacy "exclude" setting.
+		$product_financial_type_id = $product->get_meta( $this->financial_type_key );
+		if ( 'exclude' === $product_financial_type_id ) {
+			return true;
+		}
+
+		// Get the Product Type.
+		$product_type = $product->get_type();
+
+		/**
+		 * Query the Entity Type for the Product.
+		 *
+		 * @since 3.0
+		 *
+		 * @param int Numeric 0 because we are querying the Entity.
+		 * @param int $product_id The WooCommerce Product ID.
+		 * @param object $product The WooCommerce Product object.
+		 */
+		$entity = apply_filters( 'wpcv_woo_civi/product/query/entity_type', '', $product->get_id(), $product );
+
+		/**
+		 * Query whether this Item should be skipped.
+		 *
+		 * @since 3.0
+		 *
+		 * @param bool $skip False because we assume that Products should not be skipped.
+		 * @param object $item The WooCommerce Item object.
+		 * @param object $product The WooCommerce Product object.
+		 * @param string $product_type The WooCommerce Product Type.
+		 * @param string $entity The mapped CiviCRM Entity.
+		 */
+		$skip = apply_filters( 'wpcv_woo_civi/products/line_item/skip', false, $item, $product, $product_type, $entity );
+
+		return $skip;
+
+	}
+
+	/**
+	 * Determines if a Line Item should be skipped.
+	 *
+	 * @since 3.0
+	 *
+	 * @param bool $skip The possibly set "skip" flag.
+	 * @param object $item The WooCommerce Item object.
+	 * @param object $product The WooCommerce Product object.
+	 * @param string $product_type The WooCommerce Product Type.
+	 * @param string $entity The mapped CiviCRM Entity.
+	 * @return bool $skip The determined "skip" flag.
+	 */
+	public function line_item_skip( $skip, $item, $product, $product_type, $entity ) {
+
+		// Exclude when empty or when specified.
+		if ( '' === $entity || 'civicrm_exclude' === $entity ) {
+			$skip = true;
+		}
+
+		return $skip;
 
 	}
 
@@ -644,23 +639,12 @@ class WPCV_Woo_Civi_Products {
 		foreach ( $items as $item_id => $item ) {
 
 			$product = $item->get_product();
-			$product_type = $product->get_type();
 
 			// Assume we should not deduct this Item because it does sync to CiviCRM.
 			$deduct = false;
 
-			// Check if this Product should not be synced to CiviCRM.
-			$product_entity_type = $product->get_meta( $this->entity_key );
-			// Our Custom Product Types always sync.
-			if ( ! array_key_exists( $product_type, WPCV_WCI()->products_custom->product_types_meta ) ) {
-				if ( '' === $product_entity_type || 'civicrm_exclude' === $product_entity_type ) {
-					$deduct = true;
-				}
-			}
-
-			// Check if this Product still has the legacy "exclude" setting.
-			$product_financial_type_id = $product->get_meta( $this->meta_key );
-			if ( 'exclude' === $product_financial_type_id ) {
+			// Deduct this Item if it should not be synced to CiviCRM.
+			if ( $this->item_should_be_skipped( $item, $product, $order ) ) {
 				$deduct = true;
 			}
 
@@ -889,6 +873,212 @@ class WPCV_Woo_Civi_Products {
 		$variation = isset( $result->data ) ? $result->data : false;
 
 		return $variation;
+
+	}
+
+	/**
+	 * Gets the Entity Type from WooCommerce Product meta.
+	 *
+	 * @since 3.0
+	 *
+	 * @param str $entity_type The possibly found Entity Type.
+	 * @param int $product_id The Product ID.
+	 * @param object $product The WooCommerce Product object.
+	 * @return str $entity_type The found Entity Type, passed through otherwise.
+	 */
+	public function entity_type_get( $entity_type, $product_id, $product = null ) {
+
+		// Pass through if already found.
+		if ( $entity_type !== '' ) {
+			return $entity_type;
+		}
+
+		// Get the Product if not supplied.
+		if ( empty( $product ) ) {
+			$product = wc_get_product( $product_id );
+		}
+
+		// Pass through if Product not found.
+		if ( empty( $product ) ) {
+			return $entity_type;
+		}
+
+		// Pass through if not an allowed Product Type.
+		$product_type = $product->get_type();
+		$product_types_with_panel = get_option( 'woocommerce_civicrm_product_types_with_panel', [] );
+		if ( ! in_array( $product_type, $product_types_with_panel ) ) {
+			return $entity_type;
+		}
+
+		// Get Entity Type from meta.
+		$entity_type = $product->get_meta( WPCV_WCI()->products->entity_key );
+
+		return $entity_type;
+
+	}
+
+	/**
+	 * Saves the Entity Type to WooCommerce Product meta.
+	 *
+	 * @since 3.0
+	 *
+	 * @param object $product The WooCommerce Product object.
+	 * @param str $entity_type The CiviCRM Entity Type.
+	 */
+	public function entity_type_save( $product, $entity_type ) {
+
+		// Bail if no Product passed in.
+		if ( empty( $product ) ) {
+			return;
+		}
+
+		// Bail if not an allowed Product Type.
+		$product_type = $product->get_type();
+		$product_types_with_panel = get_option( 'woocommerce_civicrm_product_types_with_panel', [] );
+		if ( ! in_array( $product_type, $product_types_with_panel ) ) {
+			return;
+		}
+
+		// Save Entity Type to meta.
+		$this->set_entity_meta( $product->get_id(), $entity_type );
+
+	}
+
+	/**
+	 * Gets the Financial Type ID from WooCommerce Product meta.
+	 *
+	 * @since 3.0
+	 *
+	 * @param int $financial_type_id The possibly found Financial Type ID.
+	 * @param int $product_id The Product ID.
+	 * @param object $product The WooCommerce Product object.
+	 * @return int $financial_type_id The found Financial Type ID, passed through otherwise.
+	 */
+	public function financial_type_id_get( $financial_type_id, $product_id, $product = null ) {
+
+		// Pass through if already found.
+		if ( $financial_type_id !== 0 ) {
+			return $financial_type_id;
+		}
+
+		// Get the Product if not supplied.
+		if ( empty( $product ) ) {
+			$product = wc_get_product( $product_id );
+		}
+
+		// Pass through if Product not found.
+		if ( empty( $product ) ) {
+			return $financial_type_id;
+		}
+
+		// Pass through if not an allowed Product Type.
+		$product_type = $product->get_type();
+		$product_types_with_panel = get_option( 'woocommerce_civicrm_product_types_with_panel', [] );
+		if ( ! in_array( $product_type, $product_types_with_panel ) ) {
+			return $financial_type_id;
+		}
+
+		// Return Financial Type ID if found in meta.
+		$product_financial_type_id = $product->get_meta( $this->financial_type_key );
+		if ( ! empty( $product_financial_type_id ) ) {
+			return $product_financial_type_id;
+		}
+
+		// Not found.
+		return 0;
+
+	}
+
+	/**
+	 * Saves the Financial Type ID to WooCommerce Product meta.
+	 *
+	 * @since 3.0
+	 *
+	 * @param object $product The WooCommerce Product object.
+	 * @param int $financial_type_id The Financial Type ID.
+	 */
+	public function financial_type_id_save( $product, $financial_type_id ) {
+
+		// Bail if no Product passed in.
+		if ( empty( $product ) ) {
+			return;
+		}
+
+		// Bail if not an allowed Product Type.
+		$product_type = $product->get_type();
+		$product_types_with_panel = get_option( 'woocommerce_civicrm_product_types_with_panel', [] );
+		if ( ! in_array( $product_type, $product_types_with_panel ) ) {
+			return;
+		}
+
+		// Save Financial Type ID to meta.
+		$this->set_product_meta( $product->get_id(), $financial_type_id );
+
+	}
+
+	/**
+	 * Gets the Price Field Value ID from WooCommerce Product meta.
+	 *
+	 * @since 3.0
+	 *
+	 * @param int $pfv_id The possibly found Price Field Value ID.
+	 * @param int $product_id The Product ID.
+	 * @param object $product The WooCommerce Product object.
+	 * @return int $pfv_id The found Price Field Value ID, passed through otherwise.
+	 */
+	public function pfv_id_get( $pfv_id, $product_id, $product = null ) {
+
+		// Pass through if already found.
+		if ( $pfv_id !== 0 ) {
+			return $pfv_id;
+		}
+
+		// Get the Product if not supplied.
+		if ( empty( $product ) ) {
+			$product = wc_get_product( $product_id );
+		}
+
+		// Pass through if Product not found.
+		if ( empty( $product ) ) {
+			return $pfv_id;
+		}
+
+		// Pass through if an allowed Product Type.
+		$product_type = $product->get_type();
+		$product_types_with_panel = get_option( 'woocommerce_civicrm_product_types_with_panel', [] );
+		if ( ! in_array( $product_type, $product_types_with_panel ) ) {
+			return $pfv_id;
+		}
+
+		// Return Price Field Value ID if found in meta.
+		$product_pfv_id = $product->get_meta( $this->pfv_key );
+		if ( ! empty( $product_pfv_id ) ) {
+			return $product_pfv_id;
+		}
+
+		// Not found.
+		return 0;
+
+	}
+
+	/**
+	 * Filters the Product Type options to exclude ineligible default Product Types.
+	 *
+	 * @since 3.0
+	 *
+	 * @param array $product_types The existing array of WooCommerce Product Types.
+	 * @return array $product_types The modified array of WooCommerce Product Types.
+	 */
+	public function product_types_filter( $product_types ) {
+
+		// Remove the Custom Product Types.
+		foreach ( [ 'grouped', 'external' ] as $type ) {
+			if ( array_key_exists( $type, $product_types ) ) {
+				unset( $product_types[ $type ] );
+			}
+		}
+
+		return $product_types;
 
 	}
 

--- a/includes/products/class-woo-civi-product-contribution.php
+++ b/includes/products/class-woo-civi-product-contribution.php
@@ -33,10 +33,10 @@ class WC_Product_CiviCRM_Contribution extends WC_Product_Simple {
 	 * @since 3.0
 	 *
 	 * @param WC_Product|int $product Product instance or ID.
+	 */
 	public function __construct( $product = 0 ) {
 		parent::__construct( $product );
 	}
-	 */
 
 	/**
 	 * Gets the internal Product Type name.

--- a/includes/products/class-woo-civi-product-membership.php
+++ b/includes/products/class-woo-civi-product-membership.php
@@ -33,10 +33,10 @@ class WC_Product_CiviCRM_Membership extends WC_Product_Simple {
 	 * @since 3.0
 	 *
 	 * @param WC_Product|int $product Product instance or ID.
+	 */
 	public function __construct( $product = 0 ) {
 		parent::__construct( $product );
 	}
-	 */
 
 	/**
 	 * Gets the internal Product Type name.

--- a/includes/products/class-woo-civi-product-participant.php
+++ b/includes/products/class-woo-civi-product-participant.php
@@ -33,10 +33,10 @@ class WC_Product_CiviCRM_Participant extends WC_Product_Simple {
 	 * @since 3.0
 	 *
 	 * @param WC_Product|int $product Product instance or ID.
+	 */
 	public function __construct( $product = 0 ) {
 		parent::__construct( $product );
 	}
-	 */
 
 	/**
 	 * Gets the internal Product Type name.

--- a/wpcv-woo-civi-integration.php
+++ b/wpcv-woo-civi-integration.php
@@ -153,6 +153,15 @@ class WPCV_Woo_Civi {
 	public $products_custom;
 
 	/**
+	 * WooCommerce Variable Products object.
+	 *
+	 * @since 2.2
+	 * @access public
+	 * @var object $products_variable The WooCommerce Variable Products object.
+	 */
+	public $products_variable;
+
+	/**
 	 * Campaign management object.
 	 *
 	 * @since 3.0
@@ -313,6 +322,7 @@ class WPCV_Woo_Civi {
 
 		// Include Product classes.
 		include WPCV_WOO_CIVI_PATH . 'includes/classes/class-woo-civi-products.php';
+		include WPCV_WOO_CIVI_PATH . 'includes/classes/class-woo-civi-products-variable.php';
 		include WPCV_WOO_CIVI_PATH . 'includes/classes/class-woo-civi-products-custom.php';
 
 		// Include CiviCRM Component classes.
@@ -349,6 +359,7 @@ class WPCV_Woo_Civi {
 
 		// Init Product objects.
 		$this->products = new WPCV_Woo_Civi_Products();
+		$this->products_variable = new WPCV_Woo_Civi_Products_Variable();
 		$this->products_custom = new WPCV_Woo_Civi_Products_Custom();
 
 		// Init CiviCRM Component objects.

--- a/wpcv-woo-civi-integration.php
+++ b/wpcv-woo-civi-integration.php
@@ -44,6 +44,15 @@ class WPCV_Woo_Civi {
 	public $migrate;
 
 	/**
+	 * The Admin object.
+	 *
+	 * @since 3.0
+	 * @access public
+	 * @var object $admin The Admin object.
+	 */
+	public $admin;
+
+	/**
 	 * The Helper object.
 	 *
 	 * @since 2.0
@@ -302,6 +311,9 @@ class WPCV_Woo_Civi {
 	 */
 	private function include_files() {
 
+		// Include Admin class.
+		include WPCV_WOO_CIVI_PATH . 'includes/classes/class-woo-civi-admin.php';
+
 		// Include Helper class.
 		include WPCV_WOO_CIVI_PATH . 'includes/classes/class-woo-civi-helper.php';
 
@@ -338,6 +350,9 @@ class WPCV_Woo_Civi {
 	 * @since 2.0
 	 */
 	public function setup_objects() {
+
+		// Init Admin object.
+		$this->admin = new WPCV_Woo_Civi_Admin();
 
 		// Init helper object.
 		$this->helper = new WPCV_Woo_Civi_Helper();

--- a/wpcv-woo-civi-integration.php
+++ b/wpcv-woo-civi-integration.php
@@ -194,6 +194,9 @@ class WPCV_Woo_Civi {
 			// Always define constants.
 			self::define_constants();
 
+			// Register CiviCRM configuration.
+			self::register_config_hooks();
+
 			// Enable translation first.
 			add_action( 'plugins_loaded', [ self::$instance, 'enable_translation' ] );
 
@@ -419,6 +422,80 @@ class WPCV_Woo_Civi {
 		CRM_Core_Config::clearDBCache();
 		CRM_Utils_System::flushCache();
 
+	}
+
+	/**
+	 * Register CiviCRM hooks early.
+	 *
+	 * These callbacks need to be registered as early as possible because we do
+	 * not know how early other plugins may try and bootstrap CiviCRM.
+	 *
+	 * @since 3.0
+	 */
+	public static function register_config_hooks() {
+
+		// Register custom PHP directory.
+		add_action( 'civicrm_config', [ self::$instance, 'register_custom_php_directory' ], 10 );
+
+		// Register custom template directory.
+		add_action( 'civicrm_config', [ self::$instance, 'register_custom_template_directory' ], 10 );
+
+		// Register menu callback.
+		add_filter( 'civicrm_xmlMenu', [ self::$instance, 'register_menu_callback' ], 10 );
+
+	}
+
+	/**
+	 * Register PHP directory.
+	 *
+	 * @since 2.0
+	 *
+	 * @param object $config The CiviCRM config object.
+	 */
+	public function register_custom_php_directory( &$config ) {
+
+		// Define our custom path.
+		$custom_path = WPCV_WOO_CIVI_PATH . 'assets/civicrm/custom_php';
+
+		// Add to include path.
+		$include_path = $custom_path . PATH_SEPARATOR . get_include_path();
+		// phpcs:ignore
+		set_include_path( $include_path );
+
+	}
+
+	/**
+	 * Register template directory.
+	 *
+	 * @since 2.0
+	 *
+	 * @param object $config The CiviCRM config object.
+	 */
+	public function register_custom_template_directory( &$config ) {
+
+		// Get template instance.
+		$template = CRM_Core_Smarty::singleton();
+
+		// Add our custom template directory.
+		$custom_path = WPCV_WOO_CIVI_PATH . 'assets/civicrm/custom_tpl';
+		$template->addTemplateDir( $custom_path );
+
+		// Add to include path.
+		$template_include_path = $custom_path . PATH_SEPARATOR . get_include_path();
+		// phpcs:ignore
+		set_include_path( $template_include_path );
+
+	}
+
+	/**
+	 * Register XML file.
+	 *
+	 * @since 2.0
+	 *
+	 * @param array $files The array for files used to build the menu.
+	 */
+	public function register_menu_callback( &$files ) {
+		$files[] = WPCV_WOO_CIVI_PATH . 'assets/civicrm/xml/menu.xml';
 	}
 
 	/**

--- a/wpcv-woo-civi-integration.php
+++ b/wpcv-woo-civi-integration.php
@@ -35,6 +35,15 @@ class WPCV_Woo_Civi {
 	private static $instance;
 
 	/**
+	 * The Migrate object.
+	 *
+	 * @since 3.0
+	 * @access public
+	 * @var object $migrate The Migrate object.
+	 */
+	public $migrate;
+
+	/**
 	 * The Helper object.
 	 *
 	 * @since 2.0


### PR DESCRIPTION
Adds support for Variable Products with Product Variations that can create Line Items in CiviCRM. Also adds an admin utilities page with a "CiviCRM Event to Product" metabox that allows easy creation of WooCommerce Products - especially Variable Products with Product Variations from Price Sets attached to CiviCRM Events.