### PR TITLE
Do not convert numbers to human-readable

### DIFF
--- a/includes/classes/class-woo-civi-contribution.php
+++ b/includes/classes/class-woo-civi-contribution.php
@@ -577,7 +577,7 @@ class WPCV_Woo_Civi_Contribution {
 		 *
 		 * @see https://lab.civicrm.org/dev/financial/-/issues/189
 		 */
-		//$params['total_amount'] = WPCV_WCI()->helper->get_civicrm_float( $order->get_total() );
+		//$params['total_amount'] = $order->get_total();
 
 		/**
 		 * Filter the Order params before calling the CiviCRM API.
@@ -674,7 +674,7 @@ class WPCV_Woo_Civi_Contribution {
 
 		$params = [
 			'contribution_id' => $contribution['id'],
-			'total_amount' => WPCV_WCI()->helper->get_civicrm_float( $order->get_total() ),
+			'total_amount' => $order->get_total(),
 			'trxn_date' => $order->get_date_paid()->date( 'Y-m-d H:i:s' ),
 			/* translators: %d: The numeric ID of the WooCommerce Order */
 			'trxn_id' => sprintf( __( 'WooCommerce Order - %d', 'wpcv-woo-civi-integration' ), (int) $order_id ),

--- a/includes/classes/class-woo-civi-products.php
+++ b/includes/classes/class-woo-civi-products.php
@@ -259,11 +259,11 @@ class WPCV_Woo_Civi_Products {
 			$line_item_data = [
 				'entity_table' => 'civicrm_contribution',
 				'price_field_id' => $default_price_field_id,
-				'unit_price' => WPCV_WCI()->helper->get_civicrm_float( $product->get_price() ),
+				'unit_price' => $product->get_price(),
 				'qty' => $item->get_quantity(),
 				// The "line_total" must equal the unit_price × qty.
-				'line_total' => WPCV_WCI()->helper->get_civicrm_float( $item->get_total() ),
-				'tax_amount' => WPCV_WCI()->helper->get_civicrm_float( $item->get_total_tax() ),
+				'line_total' => $item->get_total(),
+				'tax_amount' => $item->get_total_tax(),
 				'label' => $product->get_name(),
 			];
 
@@ -472,8 +472,7 @@ class WPCV_Woo_Civi_Products {
 			$shipping_cost = 0;
 		}
 
-		// Ensure number format is CiviCRM-compliant.
-		$shipping_cost = WPCV_WCI()->helper->get_civicrm_float( $shipping_cost );
+		// Bail if no Shipping.
 		if ( ! ( floatval( $shipping_cost ) > 0 ) ) {
 			return $params;
 		}

--- a/includes/classes/class-woo-civi-tax.php
+++ b/includes/classes/class-woo-civi-tax.php
@@ -117,8 +117,8 @@ class WPCV_Woo_Civi_Tax {
 		// TODO: Review when float issues are resolved.
 		return $params;
 
-		// Ensure number format is CiviCRM-compliant.
-		$params['tax_amount'] = WPCV_WCI()->helper->get_civicrm_float( $total_tax );
+		// Assign Tax to CiviCRM API params.
+		$params['tax_amount'] = $total_tax;
 
 		/*
 		 * Some notes on overriding the Financial Type.
@@ -205,7 +205,7 @@ class WPCV_Woo_Civi_Tax {
 		// Grab the Line Item data.
 		$line_item_data = array_pop( $line_item['line_item'] );
 
-		$line_item_data['tax_amount'] = WPCV_WCI()->helper->get_civicrm_float( $item->get_total_tax() );
+		$line_item_data['tax_amount'] = $item->get_total_tax();
 
 		// Apply Tax to Line Item.
 		$line_item = [


### PR DESCRIPTION
The Order API and Payment API calls fail when amounts of 1000 or greater are submitted.