### PR TITLE
Relegate Custom Product Types to dev status

### DIFF
--- a/assets/civicrm/custom_php/CRM/Contact/Page/View/Purchases.php
+++ b/assets/civicrm/custom_php/CRM/Contact/Page/View/Purchases.php
@@ -55,8 +55,8 @@ class CRM_Contact_Page_View_Purchases extends CRM_Core_Page {
        *
        * @since 2.0
        *
-       * @param str $url The URL for the new Order.
-       * @param int $uid The numeric ID of the WordPress User.
+       * @param string $url The URL for the new Order.
+       * @param integer $uid The numeric ID of the WordPress User.
        */
       $new_order_url = apply_filters('wpcv_woo_civi/add_order/url', $url, $uid);
 

--- a/assets/templates/metaboxes/metabox-admin-contribution.php
+++ b/assets/templates/metaboxes/metabox-admin-contribution.php
@@ -20,7 +20,7 @@ defined( 'ABSPATH' ) || exit;
 do_action( 'wpcv_woo_civi/admin/metabox/contribution/before' );
 
 ?>
-<p><em><?php _e( 'Configure the Product that you want to create.', 'wpcv-woo-civi-integration' ); ?></em></p>
+<p><em><?php esc_html_e( 'Configure the Product that you want to create.', 'wpcv-woo-civi-integration' ); ?></em></p>
 
 <?php if ( empty( $metabox['args']['custom_product_type_exists'] ) ) : ?>
 	<input type="hidden" id="wpcv_wci_contribution_product_type" name="wpcv_wci_contribution_product_type" value="simple" />
@@ -30,7 +30,7 @@ do_action( 'wpcv_woo_civi/admin/metabox/contribution/before' );
 	<?php if ( ! empty( $metabox['args']['custom_product_type_exists'] ) ) : ?>
 		<tr>
 			<th scope="row">
-				<label for="wpcv_wci_contribution_product_type"><?php _e( 'Product Type', 'wpcv-woo-civi-integration' ); ?></label>
+				<label for="wpcv_wci_contribution_product_type"><?php esc_html_e( 'Product Type', 'wpcv-woo-civi-integration' ); ?></label>
 			</th>
 			<td>
 				<p>
@@ -44,7 +44,7 @@ do_action( 'wpcv_woo_civi/admin/metabox/contribution/before' );
 	<?php endif; ?>
 	<tr>
 		<th scope="row">
-			<label for="wpcv_wci_contribution_financial_type_id"><?php _e( 'Financial Type', 'wpcv-woo-civi-integration' ); ?></label>
+			<label for="wpcv_wci_contribution_financial_type_id"><?php esc_html_e( 'Financial Type', 'wpcv-woo-civi-integration' ); ?></label>
 		</th>
 		<td>
 			<?php if ( ! empty( $metabox['args']['financial_types'] ) ) : ?>
@@ -55,13 +55,13 @@ do_action( 'wpcv_woo_civi/admin/metabox/contribution/before' );
 						<?php endforeach; ?>
 					</select>
 				</p>
-				<p class="description"><?php _e( 'Choose the Financial Type that is assigned to Contribution Payments. When using a Price Field Value that is part of a Price Set, the Financial Type assigned to the Price Field Value will be used.', 'wpcv-woo-civi-integration' ); ?></p>
+				<p class="description"><?php esc_html_e( 'Choose the Financial Type that is assigned to Contribution Payments. When using a Price Field Value that is part of a Price Set, the Financial Type assigned to the Price Field Value will be used.', 'wpcv-woo-civi-integration' ); ?></p>
 			<?php endif; ?>
 		</td>
 	</tr>
 	<tr>
 		<th scope="row">
-			<label for="wpcv_wci_contribution_variations_pfv_ids"><?php _e( 'Price Field Value', 'wpcv-woo-civi-integration' ); ?></label>
+			<label for="wpcv_wci_contribution_variations_pfv_ids"><?php esc_html_e( 'Price Field Value', 'wpcv-woo-civi-integration' ); ?></label>
 		</th>
 		<td>
 			<?php if ( ! empty( $metabox['args']['price_sets'] ) ) : ?>
@@ -78,7 +78,7 @@ do_action( 'wpcv_woo_civi/admin/metabox/contribution/before' );
 						<?php endforeach; ?>
 					</select>
 				</p>
-				<p class="description"><?php _e( 'When you select more than one Price Field Value, a Variable Product will be created instead. Only add Price Field Values from the same Price Set.', 'wpcv-woo-civi-integration' ); ?></p>
+				<p class="description"><?php esc_html_e( 'When you select more than one Price Field Value, a Variable Product will be created instead. Only add Price Field Values from the same Price Set.', 'wpcv-woo-civi-integration' ); ?></p>
 			<?php endif; ?>
 		</td>
 	</tr>

--- a/assets/templates/metaboxes/metabox-admin-event.php
+++ b/assets/templates/metaboxes/metabox-admin-event.php
@@ -23,7 +23,7 @@ do_action( 'wpcv_woo_civi/admin/metabox/event/before' );
 <table class="form-table">
 	<tr>
 		<th scope="row">
-			<label for="wpcv_wci_event_id"><?php _e( 'Source Event', 'wpcv-woo-civi-integration' ); ?></label>
+			<label for="wpcv_wci_event_id"><?php esc_html_e( 'Source Event', 'wpcv-woo-civi-integration' ); ?></label>
 		</th>
 		<td>
 			<?php if ( ! empty( $metabox['args']['events'] ) ) : ?>
@@ -35,7 +35,7 @@ do_action( 'wpcv_woo_civi/admin/metabox/event/before' );
 						<?php endforeach; ?>
 					</select>
 				</p>
-				<p class="description"><?php _e( 'Choose the CiviCRM Event that you want to create the Product from.', 'wpcv-woo-civi-integration' ); ?></p>
+				<p class="description"><?php esc_html_e( 'Choose the CiviCRM Event that you want to create the Product from.', 'wpcv-woo-civi-integration' ); ?></p>
 			<?php endif; ?>
 		</td>
 	</tr>
@@ -43,7 +43,7 @@ do_action( 'wpcv_woo_civi/admin/metabox/event/before' );
 
 <hr>
 
-<p><em><?php _e( 'Configure the Product that you want to create.', 'wpcv-woo-civi-integration' ); ?></em></p>
+<p><em><?php esc_html_e( 'Configure the Product that you want to create.', 'wpcv-woo-civi-integration' ); ?></em></p>
 
 <?php if ( empty( $metabox['args']['custom_product_type_exists'] ) ) : ?>
 	<input type="hidden" id="wpcv_wci_event_product_type" name="wpcv_wci_event_product_type" value="simple" />
@@ -53,7 +53,7 @@ do_action( 'wpcv_woo_civi/admin/metabox/event/before' );
 	<?php if ( ! empty( $metabox['args']['custom_product_type_exists'] ) ) : ?>
 		<tr>
 			<th scope="row">
-				<label for="wpcv_wci_event_product_type"><?php _e( 'Product Type', 'wpcv-woo-civi-integration' ); ?></label>
+				<label for="wpcv_wci_event_product_type"><?php esc_html_e( 'Product Type', 'wpcv-woo-civi-integration' ); ?></label>
 			</th>
 			<td>
 				<p>
@@ -67,7 +67,7 @@ do_action( 'wpcv_woo_civi/admin/metabox/event/before' );
 	<?php endif; ?>
 	<tr>
 		<th scope="row">
-			<label for="wpcv_wci_event_role_id"><?php _e( 'Participant Role', 'wpcv-woo-civi-integration' ); ?></label>
+			<label for="wpcv_wci_event_role_id"><?php esc_html_e( 'Participant Role', 'wpcv-woo-civi-integration' ); ?></label>
 		</th>
 		<td>
 			<?php if ( ! empty( $metabox['args']['roles'] ) ) : ?>
@@ -83,7 +83,7 @@ do_action( 'wpcv_woo_civi/admin/metabox/event/before' );
 	</tr>
 	<tr>
 		<th scope="row">
-			<label for="wpcv_wci_event_financial_type_id"><?php _e( 'Financial Type', 'wpcv-woo-civi-integration' ); ?></label>
+			<label for="wpcv_wci_event_financial_type_id"><?php esc_html_e( 'Financial Type', 'wpcv-woo-civi-integration' ); ?></label>
 		</th>
 		<td>
 			<?php if ( ! empty( $metabox['args']['financial_types'] ) ) : ?>
@@ -94,13 +94,13 @@ do_action( 'wpcv_woo_civi/admin/metabox/event/before' );
 						<?php endforeach; ?>
 					</select>
 				</p>
-				<p class="description"><?php _e( 'Choose the Financial Type that is assigned to Payments made by Participants. When using a Price Field Value that is part of a Price Set, the Financial Type assigned to the Price Field Value will be used.', 'wpcv-woo-civi-integration' ); ?></p>
+				<p class="description"><?php esc_html_e( 'Choose the Financial Type that is assigned to Payments made by Participants. When using a Price Field Value that is part of a Price Set, the Financial Type assigned to the Price Field Value will be used.', 'wpcv-woo-civi-integration' ); ?></p>
 			<?php endif; ?>
 		</td>
 	</tr>
 	<tr>
 		<th scope="row">
-			<label for="wpcv_wci_event_variations_pfv_ids"><?php _e( 'Price Field Value', 'wpcv-woo-civi-integration' ); ?></label>
+			<label for="wpcv_wci_event_variations_pfv_ids"><?php esc_html_e( 'Price Field Value', 'wpcv-woo-civi-integration' ); ?></label>
 		</th>
 		<td>
 			<?php if ( ! empty( $metabox['args']['price_sets'] ) ) : ?>
@@ -117,7 +117,7 @@ do_action( 'wpcv_woo_civi/admin/metabox/event/before' );
 						<?php endforeach; ?>
 					</select>
 				</p>
-				<p class="description"><?php _e( 'When you select more than one Price Field Value, a Variable Product will be created instead. Only add Price Field Values from the same Price Set.', 'wpcv-woo-civi-integration' ); ?></p>
+				<p class="description"><?php esc_html_e( 'When you select more than one Price Field Value, a Variable Product will be created instead. Only add Price Field Values from the same Price Set.', 'wpcv-woo-civi-integration' ); ?></p>
 			<?php endif; ?>
 		</td>
 	</tr>

--- a/assets/templates/metaboxes/metabox-admin-membership.php
+++ b/assets/templates/metaboxes/metabox-admin-membership.php
@@ -20,7 +20,7 @@ defined( 'ABSPATH' ) || exit;
 do_action( 'wpcv_woo_civi/admin/metabox/membership/before' );
 
 ?>
-<p><em><?php _e( 'Configure the Product that you want to create.', 'wpcv-woo-civi-integration' ); ?></em></p>
+<p><em><?php esc_html_e( 'Configure the Product that you want to create.', 'wpcv-woo-civi-integration' ); ?></em></p>
 
 <?php if ( empty( $metabox['args']['custom_product_type_exists'] ) ) : ?>
 	<input type="hidden" id="wpcv_wci_membership_product_type" name="wpcv_wci_membership_product_type" value="simple" />
@@ -30,7 +30,7 @@ do_action( 'wpcv_woo_civi/admin/metabox/membership/before' );
 	<?php if ( ! empty( $metabox['args']['custom_product_type_exists'] ) ) : ?>
 		<tr>
 			<th scope="row">
-				<label for="wpcv_wci_membership_product_type"><?php _e( 'Product Type', 'wpcv-woo-civi-integration' ); ?></label>
+				<label for="wpcv_wci_membership_product_type"><?php esc_html_e( 'Product Type', 'wpcv-woo-civi-integration' ); ?></label>
 			</th>
 			<td>
 				<p>
@@ -44,7 +44,7 @@ do_action( 'wpcv_woo_civi/admin/metabox/membership/before' );
 	<?php endif; ?>
 	<tr>
 		<th scope="row">
-			<label for="wpcv_wci_membership_financial_type_id"><?php _e( 'Financial Type', 'wpcv-woo-civi-integration' ); ?></label>
+			<label for="wpcv_wci_membership_financial_type_id"><?php esc_html_e( 'Financial Type', 'wpcv-woo-civi-integration' ); ?></label>
 		</th>
 		<td>
 			<?php if ( ! empty( $metabox['args']['financial_types'] ) ) : ?>
@@ -55,13 +55,13 @@ do_action( 'wpcv_woo_civi/admin/metabox/membership/before' );
 						<?php endforeach; ?>
 					</select>
 				</p>
-				<p class="description"><?php _e( 'Choose the Financial Type that is assigned to Payments made by Members. When using a Price Field Value that is part of a Price Set, the Financial Type assigned to the Price Field Value will be used.', 'wpcv-woo-civi-integration' ); ?></p>
+				<p class="description"><?php esc_html_e( 'Choose the Financial Type that is assigned to Payments made by Members. When using a Price Field Value that is part of a Price Set, the Financial Type assigned to the Price Field Value will be used.', 'wpcv-woo-civi-integration' ); ?></p>
 			<?php endif; ?>
 		</td>
 	</tr>
 	<tr>
 		<th scope="row">
-			<label for="wpcv_wci_type_id"><?php _e( 'Membership Type', 'wpcv-woo-civi-integration' ); ?></label>
+			<label for="wpcv_wci_type_id"><?php esc_html_e( 'Membership Type', 'wpcv-woo-civi-integration' ); ?></label>
 		</th>
 		<td>
 			<?php if ( ! empty( $metabox['args']['types'] ) ) : ?>
@@ -77,7 +77,7 @@ do_action( 'wpcv_woo_civi/admin/metabox/membership/before' );
 	</tr>
 	<tr>
 		<th scope="row">
-			<label for="wpcv_wci_membership_variations_pfv_ids"><?php _e( 'Price Field Value', 'wpcv-woo-civi-integration' ); ?></label>
+			<label for="wpcv_wci_membership_variations_pfv_ids"><?php esc_html_e( 'Price Field Value', 'wpcv-woo-civi-integration' ); ?></label>
 		</th>
 		<td>
 			<?php if ( ! empty( $metabox['args']['price_sets'] ) ) : ?>
@@ -94,7 +94,7 @@ do_action( 'wpcv_woo_civi/admin/metabox/membership/before' );
 						<?php endforeach; ?>
 					</select>
 				</p>
-				<p class="description"><?php _e( 'When you select more than one Price Field Value, a Variable Product will be created instead. Only add Price Field Values from the same Price Set.', 'wpcv-woo-civi-integration' ); ?></p>
+				<p class="description"><?php esc_html_e( 'When you select more than one Price Field Value, a Variable Product will be created instead. Only add Price Field Values from the same Price Set.', 'wpcv-woo-civi-integration' ); ?></p>
 			<?php endif; ?>
 		</td>
 	</tr>

--- a/assets/templates/metaboxes/metabox-migrate-info.php
+++ b/assets/templates/metaboxes/metabox-migrate-info.php
@@ -1,27 +1,27 @@
 <!-- assets/templates/metaboxes/metabox-migrate-info.php -->
 <?php if ( $metabox['args']['migrated'] === false ) : ?>
 
-	<h3><?php _e( 'Why migrate?', 'wpcv-woo-civi-integration' ) ?></h3>
+	<h3><?php esc_html_e( 'Why migrate?', 'wpcv-woo-civi-integration' ); ?></h3>
 
-	<p><?php _e( 'The WooCommerce CiviCRM plugin is no longer being developed and the functionality that it provides has been transferred to this plugin. New features and bug fixes will only be added to this plugin from now on. Plus you get the convenience of updating this plugin via your WordPress Updates page.', 'wpcv-woo-civi-integration' ); ?></p>
+	<p><?php esc_html_e( 'The WooCommerce CiviCRM plugin is no longer being developed and the functionality that it provides has been transferred to this plugin. New features and bug fixes will only be added to this plugin from now on. Plus you get the convenience of updating this plugin via your WordPress Updates page.', 'wpcv-woo-civi-integration' ); ?></p>
 
-	<h3><?php _e( 'What needs to be done?', 'wpcv-woo-civi-integration' ) ?></h3>
+	<h3><?php esc_html_e( 'What needs to be done?', 'wpcv-woo-civi-integration' ); ?></h3>
 
-	<p><?php _e( 'Before you go ahead and deactivate and delete the WooCommerce CiviCRM plugin, there are few things that need to be checked to make sure your site continues to work as normal.', 'wpcv-woo-civi-integration' ); ?> <em><?php _e( 'Integrate CiviCRM with WooCommerce will not affect your site until you have started one of the migration steps below, so take your time.', 'wpcv-woo-civi-integration' ); ?></em></p>
+	<p><?php esc_html_e( 'Before you go ahead and deactivate and delete the WooCommerce CiviCRM plugin, there are few things that need to be checked to make sure your site continues to work as normal.', 'wpcv-woo-civi-integration' ); ?> <em><?php esc_html_e( 'Integrate CiviCRM with WooCommerce will not affect your site until you have started one of the migration steps below, so take your time.', 'wpcv-woo-civi-integration' ); ?></em></p>
 
-	<h4><?php _e( 'Filters and Actions', 'wpcv-woo-civi-integration' ) ?></h4>
+	<h4><?php esc_html_e( 'Filters and Actions', 'wpcv-woo-civi-integration' ); ?></h4>
 
-	<p><em><?php _e( 'If you have not implemented any of the Filters or Actions from the WooCommerce CiviCRM plugin, then you can skip this section.', 'wpcv-woo-civi-integration' ); ?></em></p>
+	<p><em><?php esc_html_e( 'If you have not implemented any of the Filters or Actions from the WooCommerce CiviCRM plugin, then you can skip this section.', 'wpcv-woo-civi-integration' ); ?></em></p>
 
-	<p><?php _e( 'Filters and Actions have undergone a major overhaul and there isn’t really a simple substitution formula that we can give you. If you are technical enough to have used them to modify or extend the behaviour of the WooCommerce CiviCRM plugin, then we are confident that you are capable of figuring out their replacements by looking at the equivalent classes, functions and templates in this plugin.', 'wpcv-woo-civi-integration' ); ?> <em><?php _e( 'You need to do so before taking any further action.', 'wpcv-woo-civi-integration' ); ?></em></p>
+	<p><?php esc_html_e( 'Filters and Actions have undergone a major overhaul and there isn’t really a simple substitution formula that we can give you. If you are technical enough to have used them to modify or extend the behaviour of the WooCommerce CiviCRM plugin, then we are confident that you are capable of figuring out their replacements by looking at the equivalent classes, functions and templates in this plugin.', 'wpcv-woo-civi-integration' ); ?> <em><?php esc_html_e( 'You need to do so before taking any further action.', 'wpcv-woo-civi-integration' ); ?></em></p>
 
 	<?php if ( $metabox['args']['product-metadata'] === false ) : ?>
 
 		<div id="wpcv_woocivi_products">
 
-			<h4><?php _e( 'Product Metadata', 'wpcv-woo-civi-integration' ) ?></h4>
+			<h4><?php esc_html_e( 'Product Metadata', 'wpcv-woo-civi-integration' ); ?></h4>
 
-			<p><?php _e( 'The WooCommerce CiviCRM plugin duplicated some Product metadata in certain circumstances. Click the "Upgrade Products" button below to resolve this issue.', 'wpcv-woo-civi-integration' ); ?></p>
+			<p><?php esc_html_e( 'The WooCommerce CiviCRM plugin duplicated some Product metadata in certain circumstances. Click the "Upgrade Products" button below to resolve this issue.', 'wpcv-woo-civi-integration' ); ?></p>
 
 			<?php if ( $metabox['args']['product-offset'] !== false ) : ?>
 				<?php submit_button( esc_html__( 'Stop', 'wpcv-woo-civi-integration' ), 'secondary', 'wpcv_woocivi_products_process_stop', false ); ?>
@@ -41,9 +41,9 @@
 
 		<div id="wpcv_woocivi_orders">
 
-			<h4><?php _e( 'Order Metadata', 'wpcv-woo-civi-integration' ) ?></h4>
+			<h4><?php esc_html_e( 'Order Metadata', 'wpcv-woo-civi-integration' ); ?></h4>
 
-			<p><?php _e( 'This plugin needs to store some information in WooCommerce Order metadata so that it can perform certain tasks. Click the "Upgrade Orders" button below to start the upgrade process.', 'wpcv-woo-civi-integration' ); ?></p>
+			<p><?php esc_html_e( 'This plugin needs to store some information in WooCommerce Order metadata so that it can perform certain tasks. Click the "Upgrade Orders" button below to start the upgrade process.', 'wpcv-woo-civi-integration' ); ?></p>
 
 			<?php if ( $metabox['args']['order-offset'] !== false ) : ?>
 				<?php submit_button( esc_html__( 'Stop', 'wpcv-woo-civi-integration' ), 'secondary', 'wpcv_woocivi_orders_process_stop', false ); ?>
@@ -59,22 +59,27 @@
 
 	<?php endif; ?>
 
-	<h4><?php _e( 'Settings', 'wpcv-woo-civi-integration' ) ?></h4>
+	<h4><?php esc_html_e( 'Settings', 'wpcv-woo-civi-integration' ); ?></h4>
 
-	<p><?php _e( 'Luckily there is no uninstall routine in the WooCommerce CiviCRM plugin at present. This means that WooCommerce CiviCRM will not auto-delete its settings when it is deleted and this plugin can therefore use many of those legacy settings. There are some changes and additions to the CiviCRM settings on WooCommerce Products that cannot be automated - so you should only deactivate and delete WooCommerce CiviCRM when you are sure everything mentioned here has been attended to and you have clicked "Submit".', 'wpcv-woo-civi-integration' ); ?></p>
+	<p><?php esc_html_e( 'Luckily there is no uninstall routine in the WooCommerce CiviCRM plugin at present. This means that WooCommerce CiviCRM will not auto-delete its settings when it is deleted and this plugin can therefore use many of those legacy settings. There are some changes and additions to the CiviCRM settings on WooCommerce Products that cannot be automated - so you should only deactivate and delete WooCommerce CiviCRM when you are sure everything mentioned here has been attended to and you have clicked "Submit".', 'wpcv-woo-civi-integration' ); ?></p>
 
 <?php else : ?>
 
-	<h3><?php _e( 'Congratulations!', 'wpcv-woo-civi-integration' ) ?></h3>
+	<h3><?php esc_html_e( 'Congratulations!', 'wpcv-woo-civi-integration' ); ?></h3>
 
-	<p><em><?php _e( 'You have successfully migrated from WooCommerce CiviCRM to Integrate CiviCRM with WooCommerce.', 'wpcv-woo-civi-integration' ); ?></em></p>
+	<p><em><?php esc_html_e( 'You have successfully migrated from WooCommerce CiviCRM to Integrate CiviCRM with WooCommerce.', 'wpcv-woo-civi-integration' ); ?></em></p>
 
-	<p><?php echo sprintf(
+	<p><?php
+
+	echo sprintf(
+		/* translators: 1: Opening anchor tag, 2: Closing anchor tag */
 		__( 'You can now go to your %1$sPlugins page%2$s and deactivate the WooCommerce CiviCRM plugin.', 'wpcv-woo-civi-integration' ),
 		'<a href="' . admin_url( 'plugins.php' ) . '">',
 		'</a>'
-	); ?></p>
+	);
 
-	<p><?php _e( 'Reminder: When you have deactivated WooCommerce CiviCRM, make sure you visit the "CiviCRM" Settings Tab to configure Integrate CiviCRM with WooCommerce. You will also need to review the CiviCRM settings for every active Product in your Shop to ensure they are all properly configured.', 'wpcv-woo-civi-integration' ); ?></p>
+	?></p>
+
+	<p><?php esc_html_e( 'Reminder: When you have deactivated WooCommerce CiviCRM, make sure you visit the "CiviCRM" Settings Tab to configure Integrate CiviCRM with WooCommerce. You will also need to review the CiviCRM settings for every active Product in your Shop to ensure they are all properly configured.', 'wpcv-woo-civi-integration' ); ?></p>
 
 <?php endif; ?>

--- a/assets/templates/metaboxes/metabox-migrate-submit.php
+++ b/assets/templates/metaboxes/metabox-migrate-submit.php
@@ -3,7 +3,7 @@
 	<div id="minor-publishing">
 		<div id="misc-publishing-actions">
 			<div class="misc-pub-section">
-				<span><?php _e( 'I have checked everything mentioned here and I am ready to migrate.', 'wpcv-woo-civi-integration' ); ?></span>
+				<span><?php esc_html_e( 'I have checked everything mentioned here and I am ready to migrate.', 'wpcv-woo-civi-integration' ); ?></span>
 			</div>
 		</div>
 		<div class="clear"></div>

--- a/assets/templates/pages/page-admin-migrate.php
+++ b/assets/templates/pages/page-admin-migrate.php
@@ -21,7 +21,7 @@
 
 		<div id="poststuff">
 
-			<div id="post-body" class="metabox-holder columns-<?php echo $columns;?>">
+			<div id="post-body" class="metabox-holder columns-<?php echo $columns; ?>">
 
 				<!--<div id="post-body-content">
 				</div>--><!-- #post-body-content -->
@@ -31,7 +31,7 @@
 				</div>
 
 				<div id="postbox-container-2" class="postbox-container">
-					<?php do_meta_boxes( $screen->id, 'normal', null );  ?>
+					<?php do_meta_boxes( $screen->id, 'normal', null ); ?>
 					<?php do_meta_boxes( $screen->id, 'advanced', null ); ?>
 				</div>
 

--- a/assets/templates/pages/page-admin.php
+++ b/assets/templates/pages/page-admin.php
@@ -11,15 +11,20 @@
 ?><!-- assets/templates/pages/page-admin.php -->
 <div class="wrap">
 
-	<h1><?php _e( 'Integrate CiviCRM with WooCommerce', 'wpcv-woo-civi-integration' ); ?></h1>
+	<h1><?php esc_html_e( 'Integrate CiviCRM with WooCommerce', 'wpcv-woo-civi-integration' ); ?></h1>
 
-	<p><?php _e( 'Here are some utilities for creating Products from Entities in CiviCRM.', 'wpcv-woo-civi-integration' ); ?></p>
+	<p><?php esc_html_e( 'Here are some utilities for creating Products from Entities in CiviCRM.', 'wpcv-woo-civi-integration' ); ?></p>
 
-	<p><?php echo sprintf(
-		/* translators: %1$s: Opening anchor tag, %2$s: Closing anchor tag */
+	<p><?php
+
+	echo sprintf(
+		/* translators: 1: Opening anchor tag, 2: Closing anchor tag */
 		__( 'If you are looking for the WooCommerce settings for this plugin, you can %1$sfind them here%2$s.', 'wpcv-woo-civi-integration' ),
-		'<a href="' . admin_url( 'admin.php?page=wc-settings&tab=woocommerce_civicrm' ) . '">', '</a>'
-	); ?></p>
+		'<a href="' . admin_url( 'admin.php?page=wc-settings&tab=woocommerce_civicrm' ) . '">',
+		'</a>'
+	);
+
+	?></p>
 
 	<form method="post" id="wpcv_woocivi_admin_form" action="<?php echo $this->page_submit_url_get(); ?>">
 
@@ -35,11 +40,11 @@
 			<div id="dashboard-widgets" class="metabox-holder<?php echo $columns_css; ?>">
 
 				<div id="postbox-container-1" class="postbox-container">
-					<?php do_meta_boxes($screen->id, 'normal', '');  ?>
+					<?php do_meta_boxes( $screen->id, 'normal', '' ); ?>
 				</div>
 
 				<div id="postbox-container-2" class="postbox-container">
-					<?php do_meta_boxes($screen->id, 'side', ''); ?>
+					<?php do_meta_boxes( $screen->id, 'side', '' ); ?>
 				</div>
 
 			</div><!-- #post-body -->

--- a/assets/templates/woocommerce/admin/meta-boxes/views/html-product-data-panel-variable.php
+++ b/assets/templates/woocommerce/admin/meta-boxes/views/html-product-data-panel-variable.php
@@ -33,7 +33,7 @@ defined( 'ABSPATH' ) || exit;
 			'name' => $this->entity_key,
 			'label' => __( 'Entity Type', 'wpcv-woo-civi-integration' ),
 			'desc_tip' => 'true',
-			'description' => __( 'The CiviCRM Entity Type for this Product. Other CiviCRM settings are set in the Variations.', 'wpcv-woo-civi-integration' ),
+			'description' => __( 'The CiviCRM Entity Type for this Product. Other CiviCRM settings are applied in the Variations.', 'wpcv-woo-civi-integration' ),
 			'options' => $entity_options,
 		] );
 

--- a/assets/templates/woocommerce/admin/meta-boxes/views/html-product-data-panel-variation.php
+++ b/assets/templates/woocommerce/admin/meta-boxes/views/html-product-data-panel-variation.php
@@ -19,7 +19,7 @@ defined( 'ABSPATH' ) || exit;
 	 *
 	 * @since 3.0
 	 *
-	 * @param int $loop The position in the loop.
+	 * @param integer $loop The position in the loop.
 	 * @param array $variation_data The Product Variation data.
 	 * @param WP_Post $variation The WordPress Post data.
 	 */
@@ -55,7 +55,7 @@ defined( 'ABSPATH' ) || exit;
 	 *
 	 * @since 3.0
 	 *
-	 * @param int $loop The position in the loop.
+	 * @param integer $loop The position in the loop.
 	 * @param array $variation_data The Product Variation data.
 	 * @param WP_Post $variation The WordPress Post data.
 	 * @param string $entity The CiviCRM Entity that this Product Variation is mapped to.
@@ -92,7 +92,7 @@ defined( 'ABSPATH' ) || exit;
 	 *
 	 * @since 3.0
 	 *
-	 * @param int $loop The position in the loop.
+	 * @param integer $loop The position in the loop.
 	 * @param array $variation_data The Product Variation data.
 	 * @param WP_Post $variation The WordPress Post data.
 	 */

--- a/includes/classes/class-woo-civi-admin-migrate.php
+++ b/includes/classes/class-woo-civi-admin-migrate.php
@@ -24,7 +24,7 @@ class WPCV_Woo_Civi_Admin_Migrate {
 	 *
 	 * @since 3.0
 	 * @access public
-	 * @var str $migrate_page The Migration Page reference.
+	 * @var string $migrate_page The Migration Page reference.
 	 */
 	public $migrate_page;
 
@@ -33,7 +33,7 @@ class WPCV_Woo_Civi_Admin_Migrate {
 	 *
 	 * @since 3.0
 	 * @access public
-	 * @var str $migrate_page_slug The slug of the Migration Page.
+	 * @var string $migrate_page_slug The slug of the Migration Page.
 	 */
 	public $migrate_page_slug = 'wpcv_woocivi_migrate';
 
@@ -42,7 +42,7 @@ class WPCV_Woo_Civi_Admin_Migrate {
 	 *
 	 * @since 3.0
 	 * @access public
-	 * @var int $step_count The number of Products to process per AJAX request.
+	 * @var integer $step_count The number of Products to process per AJAX request.
 	 */
 	public $step_count = 10;
 
@@ -118,7 +118,7 @@ class WPCV_Woo_Civi_Admin_Migrate {
 		}
 
 		// Bail if we are on our "Migration" page.
-		if ( $screen->id == 'civicrm_page_' . $this->migrate_page_slug ) {
+		if ( $screen->id === 'civicrm_page_' . $this->migrate_page_slug ) {
 			return;
 		}
 
@@ -127,20 +127,25 @@ class WPCV_Woo_Civi_Admin_Migrate {
 
 			// Show general "Call to Action".
 			$message = sprintf(
+				/* translators: 1: Opening strong tag, 2: Closing strong tag */
 				__( 'You can now deactivate %1$sWooCommerce CiviCRM%2$s.', 'wpcv-woo-civi-integration' ),
-				'<strong>', '</strong>'
+				'<strong>',
+				'</strong>'
 			);
 
 			// Add a link if we are not on the "Plugins" page.
 			if ( $screen->id !== 'plugins' ) {
 
-				//Add link.
+				// Add link.
 				$link = sprintf(
+					/* translators: 1: Opening anchor tag, 2: Closing anchor tag */
 					__( 'Please visit the %1$sPlugins Page%2$s to deactivate it.', 'wpcv-woo-civi-integration' ),
-					'<a href="' . admin_url( 'plugins.php' ) . '">', '</a>'
+					'<a href="' . admin_url( 'plugins.php' ) . '">',
+					'</a>'
 				);
 
 				// Merge.
+				/* translators: 1: Message, 2: Link */
 				$message = sprintf( __( '%1$s %2$s', 'wpcv-woo-civi-integration' ), $message, $link );
 
 			}
@@ -149,10 +154,12 @@ class WPCV_Woo_Civi_Admin_Migrate {
 
 			// Show general "Call to Action".
 			$message = sprintf(
-				__( '%1$sWooCommerce CiviCRM%2$s has become %3$sIntegrate CiviCRM with WooCommerce%4$s. Please visit the %5$sMigration Page%6$s to switch over.', 'wpcv-woo-civi-integration' ),
-				'<strong>', '</strong>',
-				'<strong>', '</strong>',
-				'<a href="' . menu_page_url( 'wpcv_woocivi_migrate', false ) . '">', '</a>'
+				/* translators: 1: Opening strong tag, 2: Closing strong tag, 3: Opening anchor tag, 4: Closing anchor tag */
+				__( '%1$sWooCommerce CiviCRM%2$s has become %1$sIntegrate CiviCRM with WooCommerce%2$s. Please visit the %5$sMigration Page%6$s to switch over.', 'wpcv-woo-civi-integration' ),
+				'<strong>',
+				'</strong>',
+				'<a href="' . menu_page_url( 'wpcv_woocivi_migrate', false ) . '">',
+				'</a>'
 			);
 
 		}
@@ -172,7 +179,7 @@ class WPCV_Woo_Civi_Admin_Migrate {
 	public function admin_menu() {
 
 		// We must be network admin in Multisite.
-		if ( is_multisite() AND ! is_super_admin() ) {
+		if ( is_multisite() && ! is_super_admin() ) {
 			return;
 		}
 
@@ -195,8 +202,10 @@ class WPCV_Woo_Civi_Admin_Migrate {
 		// Register our form submit hander.
 		add_action( 'load-' . $this->migrate_page, [ $this, 'form_submitted' ] );
 
-		// Add styles and scripts only on our "Migration Page".
-		// @see wp-admin/admin-header.php
+		/*
+		 * Add styles and scripts only on our "Migration Page".
+		 * @see wp-admin/admin-header.php
+		 */
 		add_action( 'admin_head-' . $this->migrate_page, [ $this, 'admin_head' ] );
 		add_action( 'admin_print_styles-' . $this->migrate_page, [ $this, 'admin_styles' ] );
 		add_action( 'admin_print_scripts-' . $this->migrate_page, [ $this, 'admin_scripts' ] );
@@ -231,7 +240,8 @@ class WPCV_Woo_Civi_Admin_Migrate {
 			$handle,
 			plugins_url( 'assets/js/pages/page-admin-migrate.js', WPCV_WOO_CIVI_FILE ),
 			[ 'jquery', 'jquery-ui-core', 'jquery-ui-progressbar' ],
-			WPCV_WOO_CIVI_VERSION // Version.
+			WPCV_WOO_CIVI_VERSION, // Version.
+			false
 		);
 
 		$localisation = [
@@ -299,13 +309,13 @@ class WPCV_Woo_Civi_Admin_Migrate {
 	public function page_migrate() {
 
 		// We must be network admin in Multisite.
-		if ( is_multisite() AND ! is_super_admin() ) {
-			wp_die( __( 'You do not have permission to access this page.', 'wpcv-woo-civi-integration' ) );
+		if ( is_multisite() && ! is_super_admin() ) {
+			wp_die( esc_html__( 'You do not have permission to access this page.', 'wpcv-woo-civi-integration' ) );
 		}
 
 		// Check user permissions.
 		if ( ! current_user_can( 'manage_options' ) ) {
-			wp_die( __( 'You do not have permission to access this page.', 'wpcv-woo-civi-integration' ) );
+			wp_die( esc_html__( 'You do not have permission to access this page.', 'wpcv-woo-civi-integration' ) );
 		}
 
 		// Get current screen.
@@ -323,7 +333,7 @@ class WPCV_Woo_Civi_Admin_Migrate {
 		do_action( 'add_meta_boxes', $screen->id, null );
 
 		// Grab columns.
-		$columns = ( 1 == $screen->get_columns() ? '1' : '2' );
+		$columns = ( 1 === $screen->get_columns() ? '1' : '2' );
 
 		// Include template file.
 		include WPCV_WOO_CIVI_PATH . 'assets/templates/pages/page-admin-migrate.php';
@@ -339,9 +349,9 @@ class WPCV_Woo_Civi_Admin_Migrate {
 	 */
 	public function page_submit_url_get() {
 
-		// Sanitise admin page url.
-		$target_url = $_SERVER['REQUEST_URI'];
-		$url_array = explode( '&', $target_url );
+		// Sanitise admin page URL.
+		$target_url = ! empty( $_SERVER['REQUEST_URI'] ) ? $_SERVER['REQUEST_URI'] : '';
+		$url_array = explode( '&', wp_unslash( $target_url ) );
 
 		// Strip flag, if present, and rebuild.
 		if ( ! empty( $url_array ) ) {
@@ -467,7 +477,7 @@ class WPCV_Woo_Civi_Admin_Migrate {
 	 * @param mixed $unused Unused param.
 	 * @param array $metabox Array containing id, title, callback, and args elements.
 	 */
-	public function meta_box_submit_render( $unused = NULL, $metabox ) {
+	public function meta_box_submit_render( $unused = null, $metabox ) {
 
 		// Include template file.
 		include WPCV_WOO_CIVI_PATH . 'assets/templates/metaboxes/metabox-migrate-submit.php';
@@ -482,7 +492,7 @@ class WPCV_Woo_Civi_Admin_Migrate {
 	 * @param mixed $unused Unused param.
 	 * @param array $metabox Array containing id, title, callback, and args elements.
 	 */
-	public function meta_box_migrate_render( $unused = NULL, $metabox ) {
+	public function meta_box_migrate_render( $unused = null, $metabox ) {
 
 		// Include template file.
 		include WPCV_WOO_CIVI_PATH . 'assets/templates/metaboxes/metabox-migrate-info.php';
@@ -564,7 +574,7 @@ class WPCV_Woo_Civi_Admin_Migrate {
 	 *
 	 * @since 3.0
 	 *
-	 * @param str $mode Pass 'updated' to append the extra param.
+	 * @param string $mode Pass 'updated' to append the extra param.
 	 */
 	private function form_redirect( $mode = '' ) {
 
@@ -591,11 +601,13 @@ class WPCV_Woo_Civi_Admin_Migrate {
 	 */
 	public function products_get_count() {
 
-		$query = new WP_Query( [
+		$args = [
 			'post_type' => 'product',
 			'post_status' => 'any',
-			'nopaging' => true
-		] );
+			'nopaging' => true,
+		];
+
+		$query = new WP_Query( $args );
 
 		return $query->found_posts;
 
@@ -674,7 +686,8 @@ class WPCV_Woo_Civi_Admin_Migrate {
 			}
 
 			// Loop and set up post.
-			while ( $query->have_posts() ) { $query->the_post();
+			while ( $query->have_posts() ) {
+				$query->the_post();
 
 				// Grab Product ID.
 				$product_id = get_the_ID();
@@ -717,8 +730,8 @@ class WPCV_Woo_Civi_Admin_Migrate {
 	 *
 	 * @since 3.0
 	 *
-	 * @param int $product_id The numeric ID of the Product.
-	 * @param bool $member_active True if the CiviMember Component is active.
+	 * @param integer $product_id The numeric ID of the Product.
+	 * @param bool    $member_active True if the CiviMember Component is active.
 	 */
 	public function product_process( $product_id, $member_active ) {
 
@@ -726,7 +739,7 @@ class WPCV_Woo_Civi_Admin_Migrate {
 		$duplicate = get_post_meta( $product_id, '_civicrm_contribution_type', true );
 
 		// When it does, update the proper meta and remove duplicate.
-		if ( ! empty( $duplicate ) || $duplicate == 0 ) {
+		if ( ! empty( $duplicate ) || $duplicate === 0 ) {
 			update_post_meta( $product_id, '_woocommerce_civicrm_financial_type_id', $duplicate );
 			delete_post_meta( $product_id, '_civicrm_contribution_type' );
 		}
@@ -735,7 +748,7 @@ class WPCV_Woo_Civi_Admin_Migrate {
 		$financial_type_id = get_post_meta( $product_id, 'woocommerce_civicrm_financial_type_id', true );
 
 		// When it does, update the proper meta and remove old.
-		if ( ! empty( $financial_type_id ) || $financial_type_id == 0 ) {
+		if ( ! empty( $financial_type_id ) || $financial_type_id === 0 ) {
 			update_post_meta( $product_id, '_woocommerce_civicrm_financial_type_id', $financial_type_id );
 			delete_post_meta( $product_id, 'woocommerce_civicrm_financial_type_id' );
 		}
@@ -744,7 +757,7 @@ class WPCV_Woo_Civi_Admin_Migrate {
 		$membership_type_id = get_post_meta( $product_id, 'woocommerce_civicrm_membership_type_id', true );
 
 		// When it does, update the proper meta and remove old.
-		if ( ! empty( $membership_type_id ) || $membership_type_id == 0 ) {
+		if ( ! empty( $membership_type_id ) || $membership_type_id === 0 ) {
 			if ( $member_active ) {
 				update_post_meta( $product_id, '_woocommerce_civicrm_membership_type_id', $membership_type_id );
 				// Also set the Entity Type if applicable.
@@ -771,11 +784,13 @@ class WPCV_Woo_Civi_Admin_Migrate {
 	 */
 	public function orders_get_count() {
 
-		$query = new WP_Query( [
+		$args = [
 			'post_type' => 'shop_order',
 			'post_status' => 'any',
 			'nopaging' => true,
-		] );
+		];
+
+		$query = new WP_Query( $args );
 
 		return $query->found_posts;
 
@@ -854,7 +869,8 @@ class WPCV_Woo_Civi_Admin_Migrate {
 			}
 
 			// Loop and set up post.
-			while ( $query->have_posts() ) { $query->the_post();
+			while ( $query->have_posts() ) {
+				$query->the_post();
 
 				// Grab Order ID.
 				$order_id = get_the_ID();
@@ -897,8 +913,8 @@ class WPCV_Woo_Civi_Admin_Migrate {
 	 *
 	 * @since 3.0
 	 *
-	 * @param int $order_id The numeric ID of the Order.
-	 * @param bool $campaign_active True if the CiviCampaign Component is active.
+	 * @param integer $order_id The numeric ID of the Order.
+	 * @param bool    $campaign_active True if the CiviCampaign Component is active.
 	 */
 	public function order_process( $order_id, $campaign_active ) {
 
@@ -947,7 +963,7 @@ class WPCV_Woo_Civi_Admin_Migrate {
 	 * @since 3.0
 	 *
 	 * @param string $key The unique identifier for the stepper.
-	 * @param int $offset The unique identifier for the stepper.
+	 * @return integer $offset The unique identifier for the stepper.
 	 */
 	public function stepped_offset_init( $key ) {
 
@@ -955,7 +971,7 @@ class WPCV_Woo_Civi_Admin_Migrate {
 		$option = '_wpcv_woo_civi_migrate_' . $key . '_offset';
 
 		// If the offset value doesn't exist.
-		if ( 'fgffgs' == get_option( $option, 'fgffgs' ) ) {
+		if ( 'fgffgs' === get_option( $option, 'fgffgs' ) ) {
 
 			// Start at the beginning.
 			$offset = 0;
@@ -986,7 +1002,7 @@ class WPCV_Woo_Civi_Admin_Migrate {
 		$option = '_wpcv_woo_civi_migrate_' . $key . '_offset';
 
 		// If the offset value doesn't exist.
-		if ( 'fgffgs' == get_option( $option, 'fgffgs' ) ) {
+		if ( 'fgffgs' === get_option( $option, 'fgffgs' ) ) {
 			return false;
 		}
 

--- a/includes/classes/class-woo-civi-admin-migrate.php
+++ b/includes/classes/class-woo-civi-admin-migrate.php
@@ -994,7 +994,7 @@ class WPCV_Woo_Civi_Admin_Migrate {
 	 * @since 3.0
 	 *
 	 * @param string $key The unique identifier for the stepper.
-	 * @return int|bool $offset The numeric value of the stepper, or false otherwise.
+	 * @return integer|bool $offset The numeric value of the stepper, or false otherwise.
 	 */
 	public function stepped_offset_get( $key ) {
 

--- a/includes/classes/class-woo-civi-campaign-utm.php
+++ b/includes/classes/class-woo-civi-campaign-utm.php
@@ -98,7 +98,7 @@ class WPCV_Woo_Civi_UTM {
 		 *
 		 * @since 2.2
 		 *
-		 * @param int The duration of the cookie. Default 0.
+		 * @param integer The duration of the cookie. Default 0.
 		 */
 		$expire = apply_filters( 'wpcv_woo_civi/utm_cookie/expire', 0 );
 		$secure = ( 'https' === wp_parse_url( home_url(), PHP_URL_SCHEME ) );
@@ -155,8 +155,9 @@ class WPCV_Woo_Civi_UTM {
 	 * @since 2.2
 	 * @since 3.0 Used only on new Orders.
 	 *
-	 * @param array $campaign_id The calculated Campaign ID.
-	 * @param object $order The WooCommerce Order object.
+	 * @param integer $campaign_id The calculated Campaign ID.
+	 * @param object  $order The WooCommerce Order object.
+	 * @return integer $campaign_id The possibly overridden Campaign ID.
 	 */
 	public function utm_to_order( $campaign_id, $order ) {
 
@@ -181,8 +182,8 @@ class WPCV_Woo_Civi_UTM {
 	 *
 	 * @since 3.0
 	 *
-	 * @param str $source The existing Contribution Source string.
-	 * @return str $source The modified Contribution Source string.
+	 * @param string $source The existing Contribution Source string.
+	 * @return string $source The modified Contribution Source string.
 	 */
 	public function utm_filter_source( $source ) {
 

--- a/includes/classes/class-woo-civi-campaign.php
+++ b/includes/classes/class-woo-civi-campaign.php
@@ -147,7 +147,7 @@ class WPCV_Woo_Civi_Campaign {
 	 * @since 3.0
 	 *
 	 * @param integer $order_id The Order ID.
-	 * @return int|bool $campaign_id The numeric ID of the CiviCRM Campaign, false otherwise.
+	 * @return integer|bool $campaign_id The numeric ID of the CiviCRM Campaign, false otherwise.
 	 */
 	public function get_order_meta( $order_id ) {
 		$campaign_id = get_post_meta( $order_id, $this->meta_key, true );

--- a/includes/classes/class-woo-civi-campaign.php
+++ b/includes/classes/class-woo-civi-campaign.php
@@ -34,7 +34,7 @@ class WPCV_Woo_Civi_Campaign {
 	 *
 	 * @since 3.0
 	 * @access public
-	 * @var str $meta_key The WooCommerce Order meta key.
+	 * @var string $meta_key The WooCommerce Order meta key.
 	 */
 	public $meta_key = '_woocommerce_civicrm_campaign_id';
 
@@ -146,7 +146,7 @@ class WPCV_Woo_Civi_Campaign {
 	 *
 	 * @since 3.0
 	 *
-	 * @param int $order_id The Order ID.
+	 * @param integer $order_id The Order ID.
 	 * @return int|bool $campaign_id The numeric ID of the CiviCRM Campaign, false otherwise.
 	 */
 	public function get_order_meta( $order_id ) {
@@ -159,8 +159,8 @@ class WPCV_Woo_Civi_Campaign {
 	 *
 	 * @since 3.0
 	 *
-	 * @param int $order_id The Order ID.
-	 * @param int $campaign_id The numeric ID of the CiviCRM Campaign.
+	 * @param integer $order_id The Order ID.
+	 * @param integer $campaign_id The numeric ID of the CiviCRM Campaign.
 	 */
 	public function set_order_meta( $order_id, $campaign_id ) {
 		update_post_meta( $order_id, $this->meta_key, (int) $campaign_id );
@@ -340,7 +340,7 @@ class WPCV_Woo_Civi_Campaign {
 	 *
 	 * @since 3.0
 	 *
-	 * @param int $campaign_id The numeric ID of the CiviCRM Campaign.
+	 * @param integer $campaign_id The numeric ID of the CiviCRM Campaign.
 	 * @return array|bool $campaign The array of data for CiviCRM Campaign, or false on failure.
 	 */
 	public function get_campaign_by_id( $campaign_id ) {
@@ -399,7 +399,7 @@ class WPCV_Woo_Civi_Campaign {
 	 *
 	 * @since 3.0
 	 *
-	 * @param int $campaign_name The name of the CiviCRM Campaign.
+	 * @param integer $campaign_name The name of the CiviCRM Campaign.
 	 * @return array|bool $campaign The array of data for CiviCRM Campaign, or false on failure.
 	 */
 	public function get_campaign_by_name( $campaign_name ) {
@@ -554,7 +554,7 @@ class WPCV_Woo_Civi_Campaign {
 	 *
 	 * @since 3.0
 	 *
-	 * @param array $params The existing array of params for the CiviCRM API.
+	 * @param array  $params The existing array of params for the CiviCRM API.
 	 * @param object $order The Order object.
 	 * @return array $params The modified array of params for the CiviCRM API.
 	 */
@@ -598,8 +598,8 @@ class WPCV_Woo_Civi_Campaign {
 	 *
 	 * @since 3.0
 	 *
-	 * @param int $order_id The Order ID.
-	 * @param object $order The Order object.
+	 * @param integer $order_id The Order ID.
+	 * @param object  $order The Order object.
 	 */
 	public function order_new( $order_id, $order ) {
 
@@ -624,8 +624,8 @@ class WPCV_Woo_Civi_Campaign {
 	 *
 	 * @since 3.0
 	 *
-	 * @param int $order_id The Order ID.
-	 * @param object $order The Order object.
+	 * @param integer $order_id The Order ID.
+	 * @param object  $order The Order object.
 	 */
 	public function order_updated( $order_id, $order ) {
 
@@ -635,7 +635,7 @@ class WPCV_Woo_Civi_Campaign {
 
 		// This only needs to be done once.
 		static $done;
-		if ( isset( $done ) AND $done === true ) {
+		if ( isset( $done ) && $done === true ) {
 			return;
 		}
 
@@ -652,9 +652,9 @@ class WPCV_Woo_Civi_Campaign {
 	 *
 	 * @since 2.0
 	 *
-	 * @param int $order_id The Order ID.
-	 * @param string $old_campaign_id The old Campaign.
-	 * @param string $new_campaign_id The new Campaign.
+	 * @param integer $order_id The Order ID.
+	 * @param string  $old_campaign_id The old Campaign.
+	 * @param string  $new_campaign_id The new Campaign.
 	 * @return bool True if successful, or false on failure.
 	 */
 	public function campaign_update( $order_id, $old_campaign_id, $new_campaign_id ) {
@@ -665,7 +665,7 @@ class WPCV_Woo_Civi_Campaign {
 		}
 
 		// Bail if the Campaign has not changed.
-		if ( (int) $old_campaign_id == (int) $new_campaign_id ) {
+		if ( (int) $old_campaign_id === (int) $new_campaign_id ) {
 			return true;
 		}
 
@@ -752,8 +752,8 @@ class WPCV_Woo_Civi_Campaign {
 	 *
 	 * @since 2.0
 	 *
-	 * @param string $column_name The column name.
-	 * @param int $post_id The WordPress Post ID.
+	 * @param string  $column_name The column name.
+	 * @param integer $post_id The WordPress Post ID.
 	 */
 	public function columns_content( $column_name, $post_id ) {
 
@@ -892,7 +892,7 @@ class WPCV_Woo_Civi_Campaign {
 		 *
 		 * @since 2.2
 		 *
-		 * @param str The array of Campaigns to fetch. Default 'campaigns'.
+		 * @param string The array of Campaigns to fetch. Default 'campaigns'.
 		 */
 		$campaign_array = apply_filters( 'wpcv_woo_civi/campaign/campaign_list/get', 'campaigns' );
 

--- a/includes/classes/class-woo-civi-contact-address.php
+++ b/includes/classes/class-woo-civi-contact-address.php
@@ -88,7 +88,7 @@ class WPCV_Woo_Civi_Contact_Address {
 	 *
 	 * @since 3.0
 	 *
-	 * @param array $contact The CiviCRM Contact data.
+	 * @param array  $contact The CiviCRM Contact data.
 	 * @param object $order The WooCommerce Order object.
 	 */
 	public function entities_create( $contact, $order ) {
@@ -103,7 +103,7 @@ class WPCV_Woo_Civi_Contact_Address {
 	 *
 	 * @since 3.0
 	 *
-	 * @param array $contact The CiviCRM Contact data.
+	 * @param array  $contact The CiviCRM Contact data.
 	 * @param object $order The WooCommerce Order object.
 	 */
 	public function entities_update( $contact, $order ) {
@@ -156,7 +156,7 @@ class WPCV_Woo_Civi_Contact_Address {
 						&& isset( $address['street_address'] )
 						&& $existing->street_address === $address['street_address']
 						&& CRM_Utils_Array::value( 'supplemental_address_1', $existing ) === CRM_Utils_Array::value( 'supplemental_address_1', $address )
-						&& $existing->city == $address['city']
+						&& $existing->city === $address['city']
 						&& $existing->postal_code === $address['postal_code']
 					) {
 						$address_exists = true;
@@ -167,8 +167,8 @@ class WPCV_Woo_Civi_Contact_Address {
 
 					civicrm_api3( 'Address', 'create', $address );
 
-					/* translators: %1$s: Address Type, %2$s: Street Address */
 					$note = sprintf(
+						/* translators: 1: Address Type, 2: Street Address */
 						__( 'Created new CiviCRM Address of type %1$s: %2$s', 'wpcv-woo-civi-integration' ),
 						$address_type,
 						$address['street_address']
@@ -300,10 +300,10 @@ class WPCV_Woo_Civi_Contact_Address {
 	 *
 	 * @since 2.0
 	 *
-	 * @param string $op The operation being performed.
-	 * @param string $object_name The entity name.
-	 * @param int $object_id The entity ID.
-	 * @param object $object_ref The entity object.
+	 * @param string  $op The operation being performed.
+	 * @param string  $object_name The entity name.
+	 * @param integer $object_id The entity ID.
+	 * @param object  $object_ref The entity object.
 	 */
 	public function sync_civi_contact_address( $op, $object_name, $object_id, $object_ref ) {
 
@@ -362,7 +362,7 @@ class WPCV_Woo_Civi_Contact_Address {
 		 *
 		 * @since 2.0
 		 *
-		 * @param int $user_id The WordPress User ID.
+		 * @param integer $user_id The WordPress User ID.
 		 * @param string $address_type The WooCommerce Address Type. Either 'billing' or 'shipping'.
 		 */
 		do_action( 'wpcv_woo_civi/wc_address/updated', $cms_user['uf_id'], $address_type );
@@ -376,8 +376,8 @@ class WPCV_Woo_Civi_Contact_Address {
 	 *
 	 * @since 2.0
 	 *
-	 * @param int $user_id The WordPress User ID.
-	 * @param string $load_address The Address Type. Either 'shipping' or 'billing'.
+	 * @param integer $user_id The WordPress User ID.
+	 * @param string  $load_address The Address Type. Either 'shipping' or 'billing'.
 	 * @return bool True on success, false on failure.
 	 */
 	public function sync_wp_user_woocommerce_address( $user_id, $load_address ) {
@@ -483,7 +483,7 @@ class WPCV_Woo_Civi_Contact_Address {
 		 *
 		 * @since 2.0
 		 *
-		 * @param int $contact_id The CiviCRM Contact ID.
+		 * @param integer $contact_id The CiviCRM Contact ID.
 		 * @param array $address The CiviCRM Address that has been edited.
 		 */
 		do_action( 'wpcv_woo_civi/civi_address/updated', $contact['contact_id'], $create_address );
@@ -499,7 +499,7 @@ class WPCV_Woo_Civi_Contact_Address {
 	 * @since 3.0
 	 *
 	 * @param integer $contact_id The numeric ID of the Contact.
-	 * @param array $addresses The array of data for the Addresses, or empty if none.
+	 * @return array $addresses The array of data for the Addresses, or empty if none.
 	 */
 	public function addresses_get_by_contact_id( $contact_id ) {
 
@@ -520,7 +520,7 @@ class WPCV_Woo_Civi_Contact_Address {
 		$result = civicrm_api3( 'Address', 'get', $params );
 
 		// Bail if there's an error.
-		if ( ! empty( $result['is_error'] ) AND $result['is_error'] == 1 ) {
+		if ( ! empty( $result['is_error'] ) && 1 === (int) $result['is_error'] ) {
 			return $addresses;
 		}
 
@@ -529,8 +529,8 @@ class WPCV_Woo_Civi_Contact_Address {
 			return $addresses;
 		}
 
- 		// Return the result set as an array of objects.
- 		foreach( $result['values'] AS $item ) {
+		// Return the result set as an array of objects.
+		foreach ( $result['values'] as $item ) {
 			$addresses[] = (object) $item;
 		}
 
@@ -544,7 +544,7 @@ class WPCV_Woo_Civi_Contact_Address {
 	 * @since 3.0
 	 *
 	 * @param integer $contact_id The numeric ID of the Contact.
-	 * @param array $address The Address data object, or false if none.
+	 * @return array $address The Address data object, or false if none.
 	 */
 	public function address_get_primary_by_contact_id( $contact_id ) {
 
@@ -567,7 +567,7 @@ class WPCV_Woo_Civi_Contact_Address {
 		$result = civicrm_api( 'Address', 'get', $params );
 
 		// Bail if there's an error.
-		if ( ! empty( $result['is_error'] ) AND $result['is_error'] == 1 ) {
+		if ( ! empty( $result['is_error'] ) && 1 === (int) $result['is_error'] ) {
 			return $address;
 		}
 
@@ -576,7 +576,7 @@ class WPCV_Woo_Civi_Contact_Address {
 			return $address;
 		}
 
- 		// The result set should contain only one item.
+		// The result set should contain only one item.
 		$address = (object) array_pop( $result['values'] );
 
 		return $address;
@@ -589,7 +589,7 @@ class WPCV_Woo_Civi_Contact_Address {
 	 * @since 3.0
 	 *
 	 * @param integer $contact_id The numeric ID of the Contact.
-	 * @param array $address The Address data object, or false if none.
+	 * @return array $address The Address data object, or false if none.
 	 */
 	public function address_get_billing_by_contact_id( $contact_id ) {
 
@@ -615,7 +615,7 @@ class WPCV_Woo_Civi_Contact_Address {
 		$result = civicrm_api( 'Address', 'get', $params );
 
 		// Bail if there's an error.
-		if ( ! empty( $result['is_error'] ) AND $result['is_error'] == 1 ) {
+		if ( ! empty( $result['is_error'] ) && 1 === (int) $result['is_error'] ) {
 			return $address;
 		}
 
@@ -624,7 +624,7 @@ class WPCV_Woo_Civi_Contact_Address {
 			return $address;
 		}
 
- 		// The result set should contain only one item.
+		// The result set should contain only one item.
 		$address = (object) array_pop( $result['values'] );
 
 		return $address;
@@ -637,7 +637,7 @@ class WPCV_Woo_Civi_Contact_Address {
 	 * @since 3.0
 	 *
 	 * @param integer $contact_id The numeric ID of the Contact.
-	 * @param array $address The Address data object, or false if none.
+	 * @return array $address The Address data object, or false if none.
 	 */
 	public function addresses_get_billing_by_contact_id( $contact_id ) {
 
@@ -660,7 +660,7 @@ class WPCV_Woo_Civi_Contact_Address {
 		$result = civicrm_api( 'Address', 'get', $params );
 
 		// Bail if there's an error.
-		if ( ! empty( $result['is_error'] ) AND $result['is_error'] == 1 ) {
+		if ( ! empty( $result['is_error'] ) && 1 === (int) $result['is_error'] ) {
 			return $addresses;
 		}
 
@@ -669,8 +669,8 @@ class WPCV_Woo_Civi_Contact_Address {
 			return $addresses;
 		}
 
- 		// Return the result set as an array of objects.
- 		foreach( $result['values'] AS $item ) {
+		// Return the result set as an array of objects.
+		foreach ( $result['values'] as $item ) {
 			$addresses[] = (object) $item;
 		}
 

--- a/includes/classes/class-woo-civi-contact-email.php
+++ b/includes/classes/class-woo-civi-contact-email.php
@@ -350,7 +350,7 @@ class WPCV_Woo_Civi_Contact_Email {
 	 * @since 3.0
 	 *
 	 * @param object $order The WooCommerce Order object.
-	 * @return str|bool $email The Email of the current User, or false if not found.
+	 * @return string|bool $email The Email of the current User, or false if not found.
 	 */
 	public function get_by_order( $order ) {
 

--- a/includes/classes/class-woo-civi-contact-email.php
+++ b/includes/classes/class-woo-civi-contact-email.php
@@ -63,7 +63,7 @@ class WPCV_Woo_Civi_Contact_Email {
 	 *
 	 * @since 3.0
 	 *
-	 * @param array $contact The CiviCRM Contact data.
+	 * @param array  $contact The CiviCRM Contact data.
 	 * @param object $order The WooCommerce Order object.
 	 */
 	public function entities_create( $contact, $order ) {
@@ -78,7 +78,7 @@ class WPCV_Woo_Civi_Contact_Email {
 	 *
 	 * @since 3.0
 	 *
-	 * @param array $contact The CiviCRM Contact data.
+	 * @param array  $contact The CiviCRM Contact data.
 	 * @param object $order The WooCommerce Order object.
 	 */
 	public function entities_update( $contact, $order ) {
@@ -123,8 +123,8 @@ class WPCV_Woo_Civi_Contact_Email {
 
 					civicrm_api3( 'Email', 'create', $email );
 
-					/* translators: %1$s: Location Type, %2$s: Email Address */
 					$note = sprintf(
+						/* translators: 1: Location Type, 2: Email Address */
 						__( 'Created new CiviCRM Email of type %1$s: %2$s', 'wpcv-woo-civi-integration' ),
 						$location_type,
 						$email['email']
@@ -169,10 +169,10 @@ class WPCV_Woo_Civi_Contact_Email {
 	 *
 	 * @since 2.0
 	 *
-	 * @param string $op The operation being performed.
-	 * @param string $object_name The entity name.
-	 * @param int $object_id The entity id.
-	 * @param object $object_ref The entity object.
+	 * @param string  $op The operation being performed.
+	 * @param string  $object_name The entity name.
+	 * @param integer $object_id The entity id.
+	 * @param object  $object_ref The entity object.
 	 */
 	public function sync_civi_contact_email( $op, $object_name, $object_id, $object_ref ) {
 
@@ -219,7 +219,7 @@ class WPCV_Woo_Civi_Contact_Email {
 		 *
 		 * @since 2.0
 		 *
-		 * @param int $user_id The WordPress User ID.
+		 * @param integer $user_id The WordPress User ID.
 		 * @param string $email_type The WooCommerce Email Type. Either 'billing' or 'shipping'.
 		 */
 		do_action( 'wpcv_woo_civi/wc_email/updated', $cms_user['uf_id'], $email_type );
@@ -233,8 +233,8 @@ class WPCV_Woo_Civi_Contact_Email {
 	 *
 	 * @since 2.0
 	 *
-	 * @param int $user_id The WordPress User ID.
-	 * @param string $load_address The Address Type. Either 'shipping' or 'billing'.
+	 * @param integer $user_id The WordPress User ID.
+	 * @param string  $load_address The Address Type. Either 'shipping' or 'billing'.
 	 * @return bool True on success, false on failure.
 	 */
 	public function sync_wp_user_woocommerce_email( $user_id, $load_address ) {
@@ -334,7 +334,7 @@ class WPCV_Woo_Civi_Contact_Email {
 		 *
 		 * @since 2.0
 		 *
-		 * @param int $contact_id The CiviCRM Contact ID.
+		 * @param integer $contact_id The CiviCRM Contact ID.
 		 * @param array $email The CiviCRM Email that has been edited.
 		 */
 		do_action( 'wpcv_woo_civi/civi_email/updated', $contact['contact_id'], $create_email );
@@ -417,7 +417,7 @@ class WPCV_Woo_Civi_Contact_Email {
 		$result = civicrm_api( 'Email', 'get', $params );
 
 		// Bail if there's an error.
-		if ( ! empty( $result['is_error'] ) AND $result['is_error'] == 1 ) {
+		if ( ! empty( $result['is_error'] ) && 1 === (int) $result['is_error'] ) {
 			return $email_data;
 		}
 

--- a/includes/classes/class-woo-civi-contact-orders-tab.php
+++ b/includes/classes/class-woo-civi-contact-orders-tab.php
@@ -123,8 +123,8 @@ class WPCV_Woo_Civi_Contact_Orders_Tab {
 	 *
 	 * @uses 'woocommerce_settings_tabs_array' filter.
 	 *
-	 * @param string $tabset_name The name of the screen or visual element.
-	 * @param array $tabs The array of tabs.
+	 * @param string       $tabset_name The name of the screen or visual element.
+	 * @param array        $tabs The array of tabs.
 	 * @param string|array $context Extra data about the screen.
 	 */
 	public function add_orders_contact_tab( $tabset_name, &$tabs, $context ) {
@@ -160,11 +160,12 @@ class WPCV_Woo_Civi_Contact_Orders_Tab {
 	 * Get Customer raw Orders.
 	 *
 	 * @since 2.2
+	 * @since 3.0 Renamed.
 	 *
-	 * @param int $contact_id The Contact ID.
+	 * @param integer $contact_id The Contact ID.
 	 * @return array $customer_orders The array of raw Order data.
 	 */
-	private function _get_orders( $contact_id ) {
+	private function get_orders_raw( $contact_id ) {
 
 		$this->fix_site();
 		$uid = abs( CRM_Core_BAO_UFMatch::getUFId( $contact_id ) );
@@ -199,13 +200,13 @@ class WPCV_Woo_Civi_Contact_Orders_Tab {
 		}
 
 		$order_statuses = [
-			'wc-pending'    => _x( 'Pending payment', 'Order status', 'woocommerce' ),
-			'wc-processing' => _x( 'Processing', 'Order status', 'woocommerce' ),
-			'wc-on-hold'    => _x( 'On hold', 'Order status', 'woocommerce' ),
-			'wc-completed'  => _x( 'Completed', 'Order status', 'woocommerce' ),
-			'wc-cancelled'  => _x( 'Cancelled', 'Order status', 'woocommerce' ),
-			'wc-refunded'   => _x( 'Refunded', 'Order status', 'woocommerce' ),
-			'wc-failed'     => _x( 'Failed', 'Order status', 'woocommerce' ),
+			'wc-pending'    => _x( 'Pending payment', 'Order status', 'wpcv-woo-civi-integration' ),
+			'wc-processing' => _x( 'Processing', 'Order status', 'wpcv-woo-civi-integration' ),
+			'wc-on-hold'    => _x( 'On hold', 'Order status', 'wpcv-woo-civi-integration' ),
+			'wc-completed'  => _x( 'Completed', 'Order status', 'wpcv-woo-civi-integration' ),
+			'wc-cancelled'  => _x( 'Cancelled', 'Order status', 'wpcv-woo-civi-integration' ),
+			'wc-refunded'   => _x( 'Refunded', 'Order status', 'wpcv-woo-civi-integration' ),
+			'wc-failed'     => _x( 'Failed', 'Order status', 'wpcv-woo-civi-integration' ),
 		];
 
 		/**
@@ -256,11 +257,11 @@ class WPCV_Woo_Civi_Contact_Orders_Tab {
 	 *
 	 * @since 2.2
 	 *
-	 * @param int $contact_id The Contact ID.
-	 * @return int $orders_count The number of Orders.
+	 * @param integer $contact_id The Contact ID.
+	 * @return integer $orders_count The number of Orders.
 	 */
 	public function count_orders( $contact_id ) {
-		return count( $this->_get_orders( $contact_id ) );
+		return count( $this->get_orders_raw( $contact_id ) );
 	}
 
 	/**
@@ -268,12 +269,12 @@ class WPCV_Woo_Civi_Contact_Orders_Tab {
 	 *
 	 * @since 2.1
 	 *
-	 * @param int $contact_id The Contact ID.
+	 * @param integer $contact_id The Contact ID.
 	 * @return array|bool $orders The array of Orders, or false on failure.
 	 */
 	public function get_orders( $contact_id ) {
 
-		$customer_orders = $this->_get_orders( $contact_id );
+		$customer_orders = $this->get_orders_raw( $contact_id );
 		$orders = [];
 		$date_format = get_option( 'date_format' ) . ' ' . get_option( 'time_format' );
 

--- a/includes/classes/class-woo-civi-contact-phone.php
+++ b/includes/classes/class-woo-civi-contact-phone.php
@@ -63,7 +63,7 @@ class WPCV_Woo_Civi_Contact_Phone {
 	 *
 	 * @since 3.0
 	 *
-	 * @param array $contact The CiviCRM Contact data.
+	 * @param array  $contact The CiviCRM Contact data.
 	 * @param object $order The WooCommerce Order object.
 	 */
 	public function entities_create( $contact, $order ) {
@@ -78,7 +78,7 @@ class WPCV_Woo_Civi_Contact_Phone {
 	 *
 	 * @since 3.0
 	 *
-	 * @param array $contact The CiviCRM Contact data.
+	 * @param array  $contact The CiviCRM Contact data.
 	 * @param object $order The WooCommerce Order object.
 	 */
 	public function entities_update( $contact, $order ) {
@@ -123,8 +123,8 @@ class WPCV_Woo_Civi_Contact_Phone {
 
 					civicrm_api3( 'Phone', 'create', $phone );
 
-					/* translators: %1$s: Location Type, %2$s: Phone Number */
 					$note = sprintf(
+						/* translators: %1$s: Location Type, %2$s: Phone Number */
 						__( 'Created new CiviCRM Phone of type %1$s: %2$s', 'wpcv-woo-civi-integration' ),
 						$location_type,
 						$phone['phone']
@@ -168,10 +168,10 @@ class WPCV_Woo_Civi_Contact_Phone {
 	 *
 	 * @since 2.0
 	 *
-	 * @param string $op The operation being performed.
-	 * @param string $object_name The entity name.
-	 * @param int $object_id The entity id.
-	 * @param object $object_ref The entity object.
+	 * @param string  $op The operation being performed.
+	 * @param string  $object_name The entity name.
+	 * @param integer $object_id The entity id.
+	 * @param object  $object_ref The entity object.
 	 */
 	public function sync_civi_contact_phone( $op, $object_name, $object_id, $object_ref ) {
 
@@ -218,8 +218,8 @@ class WPCV_Woo_Civi_Contact_Phone {
 		 *
 		 * @since 2.0
 		 *
-		 * @param int $user_id The WordPress User ID.
-		 * @param string $phone_type The WooCommerce Phone Type. Either 'billing' or 'shipping'.
+		 * @param integer $user_id The WordPress User ID.
+		 * @param string  $phone_type The WooCommerce Phone Type. Either 'billing' or 'shipping'.
 		 */
 		do_action( 'wpcv_woo_civi/wc_phone/updated', $cms_user['uf_id'], $phone_type );
 
@@ -232,8 +232,8 @@ class WPCV_Woo_Civi_Contact_Phone {
 	 *
 	 * @since 2.0
 	 *
-	 * @param int $user_id The WordPress User ID.
-	 * @param string $load_address The Address Type. Either 'shipping' or 'billing'.
+	 * @param integer $user_id The WordPress User ID.
+	 * @param string  $load_address The Address Type. Either 'shipping' or 'billing'.
 	 * @return bool True on success, false on failure.
 	 */
 	public function sync_wp_user_woocommerce_phone( $user_id, $load_address ) {
@@ -333,7 +333,7 @@ class WPCV_Woo_Civi_Contact_Phone {
 		 *
 		 * @since 2.0
 		 *
-		 * @param int $contact_id The CiviCRM Contact ID.
+		 * @param integer $contact_id The CiviCRM Contact ID.
 		 * @param array $phone The CiviCRM Phone that has been edited.
 		 */
 		do_action( 'wpcv_woo_civi/civi_phone/updated', $contact['contact_id'], $create_phone );
@@ -349,7 +349,7 @@ class WPCV_Woo_Civi_Contact_Phone {
 	 * @since 3.0
 	 *
 	 * @param integer $phone_id The numeric ID of the Phone Record.
-	 * @param array $phone The array of Phone Record data, or empty if none.
+	 * @return array $phone The array of Phone Record data, or empty if none.
 	 */
 	public function phone_get_by_id( $phone_id ) {
 
@@ -370,7 +370,7 @@ class WPCV_Woo_Civi_Contact_Phone {
 		$result = civicrm_api( 'Phone', 'get', $params );
 
 		// Bail if there's an error.
-		if ( ! empty( $result['is_error'] ) AND $result['is_error'] == 1 ) {
+		if ( ! empty( $result['is_error'] ) && 1 === (int) $result['is_error'] ) {
 			return $phone;
 		}
 
@@ -379,7 +379,7 @@ class WPCV_Woo_Civi_Contact_Phone {
 			return $phone;
 		}
 
- 		// The result set should contain only one item.
+		// The result set should contain only one item.
 		$phone = array_pop( $result['values'] );
 
 		return $phone;
@@ -422,7 +422,7 @@ class WPCV_Woo_Civi_Contact_Phone {
 		$result = civicrm_api( 'Phone', 'get', $params );
 
 		// Bail if there's an error.
-		if ( ! empty( $result['is_error'] ) AND $result['is_error'] == 1 ) {
+		if ( ! empty( $result['is_error'] ) && 1 === (int) $result['is_error'] ) {
 			return $phone_data;
 		}
 

--- a/includes/classes/class-woo-civi-contact.php
+++ b/includes/classes/class-woo-civi-contact.php
@@ -637,7 +637,7 @@ class WPCV_Woo_Civi_Contact {
 
 		// Log and bail if there's an error.
 		if ( ! empty( $result['is_error'] ) && 1 === (int) $result['is_error'] ) {
-			$e = new Exception;
+			$e = new Exception();
 			$trace = $e->getTraceAsString();
 			error_log( print_r( [
 				'method' => __METHOD__,

--- a/includes/classes/class-woo-civi-contact.php
+++ b/includes/classes/class-woo-civi-contact.php
@@ -60,7 +60,7 @@ class WPCV_Woo_Civi_Contact {
 	 *
 	 * @since 3.0
 	 * @access public
-	 * @var str $meta_key The WooCommerce Order meta key.
+	 * @var string $meta_key The WooCommerce Order meta key.
 	 */
 	public $meta_key = '_woocommerce_civicrm_contact_id';
 
@@ -69,7 +69,7 @@ class WPCV_Woo_Civi_Contact {
 	 *
 	 * @since 3.0
 	 * @access public
-	 * @var str $is_checkout True if in Checkout, false otherwise.
+	 * @var string $is_checkout True if in Checkout, false otherwise.
 	 */
 	public $is_checkout = false;
 
@@ -166,7 +166,7 @@ class WPCV_Woo_Civi_Contact {
 	 *
 	 * @since 3.0
 	 *
-	 * @param int $order_id The Order ID.
+	 * @param integer $order_id The Order ID.
 	 * @return int|bool $contact_id The numeric ID of the CiviCRM Contact, false otherwise.
 	 */
 	public function get_order_meta( $order_id ) {
@@ -179,8 +179,8 @@ class WPCV_Woo_Civi_Contact {
 	 *
 	 * @since 3.0
 	 *
-	 * @param int $order_id The Order ID.
-	 * @param int $contact_id The numeric ID of the CiviCRM Contact.
+	 * @param integer $order_id The Order ID.
+	 * @param integer $contact_id The numeric ID of the CiviCRM Contact.
 	 */
 	public function set_order_meta( $order_id, $contact_id ) {
 		update_post_meta( $order_id, $this->meta_key, (int) $contact_id );
@@ -199,7 +199,7 @@ class WPCV_Woo_Civi_Contact {
 	 * @since 3.0
 	 *
 	 * @param object $order The Order object.
-	 * @param array $data The Order data.
+	 * @param array  $data The Order data.
 	 */
 	public function checkout_create_order( $order, $data ) {
 
@@ -213,8 +213,8 @@ class WPCV_Woo_Civi_Contact {
 	 *
 	 * @since 3.0
 	 *
-	 * @param int $order_id The Order ID.
-	 * @param object $order The Order object.
+	 * @param integer $order_id The Order ID.
+	 * @param object  $order The Order object.
 	 */
 	public function order_new( $order_id, $order ) {
 
@@ -231,7 +231,7 @@ class WPCV_Woo_Civi_Contact {
 		 *
 		 * @since 3.0
 		 *
-		 * @param int $order_id The Order ID.
+		 * @param integer $order_id The Order ID.
 		 * @param object $order The Order object.
 		 */
 		do_action( 'wpcv_woo_civi/contact/order/new', $order_id, $order );
@@ -243,13 +243,13 @@ class WPCV_Woo_Civi_Contact {
 	 *
 	 * @since 3.0
 	 *
-	 * @param int $order_id The Order ID.
-	 * @param array $posted_data The posted data.
-	 * @param object $order The Order object.
+	 * @param integer $order_id The Order ID.
+	 * @param array   $posted_data The posted data.
+	 * @param object  $order The Order object.
 	 */
 	public function order_processed( $order_id, $posted_data, $order ) {
 
-		// Get the Contact ID (or false on error)
+		// Get the Contact ID - or false on error.
 		$contact_id = $this->get_id_by_order( $order );
 
 		// TODO: Do we want to bail here, or carry on if there's an error?
@@ -318,7 +318,7 @@ class WPCV_Woo_Civi_Contact {
 		$result = civicrm_api( 'Contact', 'get', $params );
 
 		// Bail if there's an error.
-		if ( ! empty( $result['is_error'] ) AND $result['is_error'] == 1 ) {
+		if ( ! empty( $result['is_error'] ) && 1 === (int) $result['is_error'] ) {
 
 			// Write to CiviCRM log.
 			CRM_Core_Error::debug_log_message( __( 'Failed to get Contact by ID', 'wpcv-woo-civi-integration' ) );
@@ -357,7 +357,7 @@ class WPCV_Woo_Civi_Contact {
 	 *
 	 * @since 3.0
 	 *
-	 * @param str $email The Email address.
+	 * @param string $email The Email address.
 	 * @return array|bool $contacts The array of CiviCRM Contacts, or false on failure.
 	 */
 	public function get_by_email( $email ) {
@@ -418,7 +418,7 @@ class WPCV_Woo_Civi_Contact {
 	 *
 	 * @since 3.0
 	 *
-	 * @param array $contact The array of CiviCRM Contact data.
+	 * @param array  $contact The array of CiviCRM Contact data.
 	 * @param string $contact_type The Contact Type. Defaults to "Individual".
 	 * @return int|boolean $contact_id The suggested Contact ID, or false on failure.
 	 */
@@ -458,9 +458,9 @@ class WPCV_Woo_Civi_Contact {
 	 *
 	 * @since 3.0
 	 *
-	 * @param array $contact The array of Contact data.
-	 * @param string $contact_type The Contact Type. Defaults to "Individual".
-	 * @param int $dedupe_rule_id The Dedupe Rule ID.
+	 * @param array   $contact The array of Contact data.
+	 * @param string  $contact_type The Contact Type. Defaults to "Individual".
+	 * @param integer $dedupe_rule_id The Dedupe Rule ID.
 	 * @return int|bool $contact_id The numeric Contact ID, or false on failure.
 	 */
 	public function get_by_dedupe_rule( $contact, $contact_type = 'Individual', $dedupe_rule_id ) {
@@ -482,7 +482,7 @@ class WPCV_Woo_Civi_Contact {
 		$contact_id = 0;
 
 		// Check for duplicates.
-		$contact_ids = CRM_Dedupe_Finder::dupesByParams( $dedupe_params, $contact_type, NULL, [], $dedupe_rule_id );
+		$contact_ids = CRM_Dedupe_Finder::dupesByParams( $dedupe_params, $contact_type, null, [], $dedupe_rule_id );
 
 		// Return the suggested Contact ID.
 		if ( ! empty( $contact_ids ) ) {
@@ -517,10 +517,10 @@ class WPCV_Woo_Civi_Contact {
 
 		// Add the Dedupe Rules for all Contact Types.
 		$types = $this->types_get();
-		foreach( $types AS $type => $name ) {
+		foreach ( $types as $type => $name ) {
 			if ( empty( $contact_type ) ) {
 				$dedupe_rules[ $type ] = CRM_Dedupe_BAO_RuleGroup::getByType( $type );
-			} elseif ( $contact_type == $type ) {
+			} elseif ( $contact_type === $type ) {
 				$dedupe_rules[ $type ] = CRM_Dedupe_BAO_RuleGroup::getByType( $type );
 			}
 		}
@@ -539,8 +539,8 @@ class WPCV_Woo_Civi_Contact {
 	 *
 	 * @since 2.0
 	 *
-	 * @param int $id The CiviCRM Contact ID or WordPress User ID.
-	 * @param string $property Either 'contact_id' or 'uf_id'.
+	 * @param integer $id The CiviCRM Contact ID or WordPress User ID.
+	 * @param string  $property Either 'contact_id' or 'uf_id'.
 	 * @return array $result The UFMatch data, or empty array on failure.
 	 */
 	public function get_ufmatch( $id, $property ) {
@@ -565,7 +565,7 @@ class WPCV_Woo_Civi_Contact {
 		$result = civicrm_api3( 'UFMatch', 'get', $params );
 
 		// Bail if there's an error.
-		if ( ! empty( $result['is_error'] ) AND $result['is_error'] == 1 ) {
+		if ( ! empty( $result['is_error'] ) && 1 === (int) $result['is_error'] ) {
 
 			// Write to CiviCRM log.
 			CRM_Core_Error::debug_log_message( __( 'Unable to retrieve CiviCRM UFMatch data.', 'wpcv-woo-civi-integration' ) );
@@ -588,7 +588,7 @@ class WPCV_Woo_Civi_Contact {
 			return $ufmatch;
 		}
 
- 		// The result set should contain only one item.
+		// The result set should contain only one item.
 		$ufmatch = array_pop( $result['values'] );
 
 		return $ufmatch;
@@ -636,15 +636,15 @@ class WPCV_Woo_Civi_Contact {
 		$result = civicrm_api3( 'Contact', 'create', $params );
 
 		// Log and bail if there's an error.
-		if ( ! empty( $result['is_error'] ) AND $result['is_error'] == 1 ) {
+		if ( ! empty( $result['is_error'] ) && 1 === (int) $result['is_error'] ) {
 			$e = new Exception;
 			$trace = $e->getTraceAsString();
-			error_log( print_r( array(
+			error_log( print_r( [
 				'method' => __METHOD__,
 				'params' => $params,
 				'result' => $result,
 				//'backtrace' => $trace,
-			), true ) );
+			], true ) );
 			return false;
 		}
 
@@ -819,8 +819,8 @@ class WPCV_Woo_Civi_Contact {
 	 *
 	 * @since 3.0
 	 *
-	 * @param int $contact_id The numeric ID if the CiviCRM Contact.
-	 * @param object $order The Order object.
+	 * @param integer $contact_id The numeric ID if the CiviCRM Contact.
+	 * @param object  $order The Order object.
 	 * @return int|bool $contact_id The numeric ID if the CiviCRM Contact, or false on failure.
 	 */
 	public function update_from_order( $contact_id, $order ) {
@@ -833,7 +833,7 @@ class WPCV_Woo_Civi_Contact {
 		 * @since 3.0
 		 *
 		 * @param bool False by default: do not bypass.
-		 * @param int $contact_id The numeric ID of the Contact.
+		 * @param integer $contact_id The numeric ID of the Contact.
 		 * @param object $order The WooCommerce Order object.
 		 */
 		if ( true === apply_filters( 'wpcv_woo_civi/contact/update_from_order/bypass', false, $contact_id, $order ) ) {
@@ -1086,7 +1086,7 @@ class WPCV_Woo_Civi_Contact {
 		$result = civicrm_api( 'ContactType', 'get', $params );
 
 		// Bail if there's an error.
-		if ( ! empty( $result['is_error'] ) && $result['is_error'] == 1 ) {
+		if ( ! empty( $result['is_error'] ) && 1 === (int) $result['is_error'] ) {
 			return $nested;
 		}
 
@@ -1108,7 +1108,7 @@ class WPCV_Woo_Civi_Contact {
 		foreach ( $top_level as $item ) {
 			$item['children'] = [];
 			foreach ( $contact_types as $contact_type ) {
-				if ( isset( $contact_type['parent_id'] ) && $contact_type['parent_id'] == $item['id'] ) {
+				if ( isset( $contact_type['parent_id'] ) && (int) $contact_type['parent_id'] === (int) $item['id'] ) {
 					$item['children'][] = $contact_type;
 				}
 			}
@@ -1167,7 +1167,7 @@ class WPCV_Woo_Civi_Contact {
 	 * @since 3.0
 	 *
 	 * @param string|integer $contact_type The name or ID of the CiviCRM Contact Type to query.
-	 * @param string $mode The param to query by: 'name' or 'id'.
+	 * @param string         $mode The param to query by: 'name' or 'id'.
 	 * @return array|bool $contact_type_data An array of Contact Type data, or false on failure.
 	 */
 	public function type_get( $contact_type, $mode = 'name' ) {
@@ -1201,9 +1201,9 @@ class WPCV_Woo_Civi_Contact {
 		];
 
 		// Add param to query by.
-		if ( $mode == 'name' ) {
+		if ( $mode === 'name' ) {
 			$params['name'] = $contact_type;
-		} elseif ( $mode == 'id' ) {
+		} elseif ( $mode === 'id' ) {
 			$params['id'] = $contact_type;
 		}
 
@@ -1211,7 +1211,7 @@ class WPCV_Woo_Civi_Contact {
 		$result = civicrm_api( 'ContactType', 'get', $params );
 
 		// Bail if there's an error.
-		if ( ! empty( $result['is_error'] ) && $result['is_error'] == 1 ) {
+		if ( ! empty( $result['is_error'] ) && 1 === (int) $result['is_error'] ) {
 			return $contact_type_data;
 		}
 

--- a/includes/classes/class-woo-civi-contact.php
+++ b/includes/classes/class-woo-civi-contact.php
@@ -167,7 +167,7 @@ class WPCV_Woo_Civi_Contact {
 	 * @since 3.0
 	 *
 	 * @param integer $order_id The Order ID.
-	 * @return int|bool $contact_id The numeric ID of the CiviCRM Contact, false otherwise.
+	 * @return integer|bool $contact_id The numeric ID of the CiviCRM Contact, false otherwise.
 	 */
 	public function get_order_meta( $order_id ) {
 		$contact_id = get_post_meta( $order_id, $this->meta_key, true );
@@ -420,7 +420,7 @@ class WPCV_Woo_Civi_Contact {
 	 *
 	 * @param array  $contact The array of CiviCRM Contact data.
 	 * @param string $contact_type The Contact Type. Defaults to "Individual".
-	 * @return int|boolean $contact_id The suggested Contact ID, or false on failure.
+	 * @return integer|boolean $contact_id The suggested Contact ID, or false on failure.
 	 */
 	public function get_by_dedupe_unsupervised( $contact, $contact_type = 'Individual' ) {
 
@@ -461,7 +461,7 @@ class WPCV_Woo_Civi_Contact {
 	 * @param array   $contact The array of Contact data.
 	 * @param string  $contact_type The Contact Type. Defaults to "Individual".
 	 * @param integer $dedupe_rule_id The Dedupe Rule ID.
-	 * @return int|bool $contact_id The numeric Contact ID, or false on failure.
+	 * @return integer|bool $contact_id The numeric Contact ID, or false on failure.
 	 */
 	public function get_by_dedupe_rule( $contact, $contact_type = 'Individual', $dedupe_rule_id ) {
 
@@ -736,7 +736,7 @@ class WPCV_Woo_Civi_Contact {
 	 * @since 3.0
 	 *
 	 * @param object $order The Order object.
-	 * @return int|bool $contact_id The numeric ID if the CiviCRM Contact, or false on failure.
+	 * @return integer|bool $contact_id The numeric ID if the CiviCRM Contact, or false on failure.
 	 */
 	public function create_from_order( $order ) {
 
@@ -821,7 +821,7 @@ class WPCV_Woo_Civi_Contact {
 	 *
 	 * @param integer $contact_id The numeric ID if the CiviCRM Contact.
 	 * @param object  $order The Order object.
-	 * @return int|bool $contact_id The numeric ID if the CiviCRM Contact, or false on failure.
+	 * @return integer|bool $contact_id The numeric ID if the CiviCRM Contact, or false on failure.
 	 */
 	public function update_from_order( $contact_id, $order ) {
 
@@ -960,9 +960,9 @@ class WPCV_Woo_Civi_Contact {
 	 * @since 3.0
 	 *
 	 * @param object $order The WooCommerce Order object.
-	 * @return int|bool $contact_id The numeric ID of the CiviCRM Contact if found.
-	 *                              Returns 0 if a CiviCRM Contact cannot be found.
-	 *                              Returns boolean false on failure.
+	 * @return integer|bool $contact_id The numeric ID of the CiviCRM Contact if found.
+	 *                                  Returns 0 if a CiviCRM Contact cannot be found.
+	 *                                  Returns boolean false on failure.
 	 */
 	public function get_id_by_order( $order ) {
 

--- a/includes/classes/class-woo-civi-contribution.php
+++ b/includes/classes/class-woo-civi-contribution.php
@@ -94,7 +94,7 @@ class WPCV_Woo_Civi_Contribution {
 	 * @since 3.0
 	 *
 	 * @param integer $order_id The Order ID.
-	 * @return int|bool $contribution_id The numeric ID of the CiviCRM Contribution, false otherwise.
+	 * @return integer|bool $contribution_id The numeric ID of the CiviCRM Contribution, false otherwise.
 	 */
 	public function get_order_meta( $order_id ) {
 		$contribution_id = get_post_meta( $order_id, $this->meta_key, true );

--- a/includes/classes/class-woo-civi-contribution.php
+++ b/includes/classes/class-woo-civi-contribution.php
@@ -34,7 +34,7 @@ class WPCV_Woo_Civi_Contribution {
 	 *
 	 * @since 3.0
 	 * @access public
-	 * @var str $meta_key The WooCommerce Order meta key.
+	 * @var string $meta_key The WooCommerce Order meta key.
 	 */
 	public $meta_key = '_woocommerce_civicrm_contribution_id';
 
@@ -73,9 +73,7 @@ class WPCV_Woo_Civi_Contribution {
 	 * @since 3.0
 	 */
 	public function register_hooks() {
-
 		// None as yet.
-
 	}
 
 	/**
@@ -95,7 +93,7 @@ class WPCV_Woo_Civi_Contribution {
 	 *
 	 * @since 3.0
 	 *
-	 * @param int $order_id The Order ID.
+	 * @param integer $order_id The Order ID.
 	 * @return int|bool $contribution_id The numeric ID of the CiviCRM Contribution, false otherwise.
 	 */
 	public function get_order_meta( $order_id ) {
@@ -108,8 +106,8 @@ class WPCV_Woo_Civi_Contribution {
 	 *
 	 * @since 3.0
 	 *
-	 * @param int $order_id The Order ID.
-	 * @param int $contribution_id The numeric ID of the CiviCRM Contribution.
+	 * @param integer $order_id The Order ID.
+	 * @param integer $contribution_id The numeric ID of the CiviCRM Contribution.
 	 */
 	public function set_order_meta( $order_id, $contribution_id ) {
 		update_post_meta( $order_id, $this->meta_key, $contribution_id );
@@ -120,7 +118,7 @@ class WPCV_Woo_Civi_Contribution {
 	 *
 	 * @since 3.0
 	 *
-	 * @param int $contribution_id The numeric ID of the CiviCRM Contribution.
+	 * @param integer $contribution_id The numeric ID of the CiviCRM Contribution.
 	 * @return array $result The CiviCRM Contribution data, or empty on failure.
 	 */
 	public function get_by_id( $contribution_id ) {
@@ -147,7 +145,7 @@ class WPCV_Woo_Civi_Contribution {
 		$result = civicrm_api( 'Contribution', 'get', $params );
 
 		// Bail if there's an error.
-		if ( ! empty( $result['is_error'] ) AND $result['is_error'] == 1 ) {
+		if ( ! empty( $result['is_error'] ) && 1 === (int) $result['is_error'] ) {
 
 			// Write to CiviCRM log.
 			CRM_Core_Error::debug_log_message( __( 'Error trying to find Contribution by ID', 'wpcv-woo-civi-integration' ) );
@@ -170,7 +168,7 @@ class WPCV_Woo_Civi_Contribution {
 			return $contribution;
 		}
 
- 		// The result set should contain only one item.
+		// The result set should contain only one item.
 		$contribution = array_pop( $result['values'] );
 
 		return $contribution;
@@ -182,7 +180,7 @@ class WPCV_Woo_Civi_Contribution {
 	 *
 	 * @since 2.2
 	 *
-	 * @param int $order_id The numeric ID of the WooCommerce Order.
+	 * @param integer $order_id The numeric ID of the WooCommerce Order.
 	 * @return array $contribution The CiviCRM Contribution data, or empty on failure.
 	 */
 	public function get_by_order_id( $order_id ) {
@@ -210,7 +208,7 @@ class WPCV_Woo_Civi_Contribution {
 	 *
 	 * @since 2.2
 	 *
-	 * @param int $post_id The WordPress Post ID.
+	 * @param integer $post_id The WordPress Post ID.
 	 * @return string $invoice_id The Invoice ID.
 	 */
 	public function get_invoice_id( $post_id ) {
@@ -266,7 +264,7 @@ class WPCV_Woo_Civi_Contribution {
 		$result = civicrm_api( 'Contribution', 'get', $params );
 
 		// Bail if there's an error.
-		if ( ! empty( $result['is_error'] ) AND $result['is_error'] == 1 ) {
+		if ( ! empty( $result['is_error'] ) && 1 === (int) $result['is_error'] ) {
 
 			// Write to CiviCRM log.
 			CRM_Core_Error::debug_log_message( __( 'Error try to find Contribution by Invoice ID', 'wpcv-woo-civi-integration' ) );
@@ -289,7 +287,7 @@ class WPCV_Woo_Civi_Contribution {
 			return $contribution;
 		}
 
- 		// The result set should contain only one item.
+		// The result set should contain only one item.
 		$contribution = array_pop( $result['values'] );
 
 		return $contribution;
@@ -653,8 +651,8 @@ class WPCV_Woo_Civi_Contribution {
 	 *
 	 * @since 3.0
 	 *
-	 * @param int $order_id The Order ID.
-	 * @param object $order The Order object.
+	 * @param integer $order_id The Order ID.
+	 * @param object  $order The Order object.
 	 * @return array|bool $payment_data The array of Payment data on success, false otherwise.
 	 */
 	public function payment_create( $order_id, $order ) {
@@ -712,7 +710,7 @@ class WPCV_Woo_Civi_Contribution {
 		 * This should not really be necessary to check because a CiviCRM Order should
 		 * not have been created for this Order - and therefore a Contribution for this
 		 * Order should not have been found by get_by_order_id() above.
- 		 */
+		 */
 		if ( 0 === (float) $params['total_amount'] ) {
 
 			// Bail when there are no Products that should sync to CiviCRM.
@@ -768,7 +766,7 @@ class WPCV_Woo_Civi_Contribution {
 	 *
 	 * @since 3.0
 	 *
-	 * @param array $contribution The array of CiviCRM Contribution data.
+	 * @param array  $contribution The array of CiviCRM Contribution data.
 	 * @param string $note The text to add as a Note.
 	 * @return array|bool The Note data on success, otherwise false.
 	 */
@@ -829,9 +827,9 @@ class WPCV_Woo_Civi_Contribution {
 	 *
 	 * @since 3.0
 	 *
-	 * @param int $order_id The Order ID.
-	 * @param object $order The Order object.
-	 * @param string $new_status_id The numeric ID of the new Status.
+	 * @param integer $order_id The Order ID.
+	 * @param object  $order The Order object.
+	 * @param string  $new_status_id The numeric ID of the new Status.
 	 * @return bool True on success, otherwise false.
 	 */
 	public function status_update( $order_id, $order, $new_status_id ) {
@@ -890,7 +888,7 @@ class WPCV_Woo_Civi_Contribution {
 		 * @since 3.0
 		 *
 		 * @param array $contribution The CiviCRM Contribution data.
-		 * @param int $order_id The WooCommerce Order ID.
+		 * @param integer $order_id The WooCommerce Order ID.
 		 * @param object $order The WooCommerce Order object.
 		 * @param string $new_status_id The numeric ID of the new Status.
 		 */
@@ -907,7 +905,7 @@ class WPCV_Woo_Civi_Contribution {
 	 * @since 2.0
 	 *
 	 * @param string $order_status The WooCommerce Order Status.
-	 * @return int $id The numeric ID of the CiviCRM Contribution Status.
+	 * @return integer $id The numeric ID of the CiviCRM Contribution Status.
 	 */
 	public function status_map( $order_status ) {
 

--- a/includes/classes/class-woo-civi-helper.php
+++ b/includes/classes/class-woo-civi-helper.php
@@ -55,13 +55,11 @@ class WPCV_Woo_Civi_Helper {
 	/**
 	 * Initialise this object.
 	 *
+	 * Empty since class properties are now populated on demand.
+	 *
 	 * @since 2.0
 	 */
-	public function initialise() {
-
-		// Empty since class properties are now populated on demand.
-
-	}
+	public function initialise() {}
 
 	/**
 	 * Get a CiviCRM Setting.
@@ -132,7 +130,7 @@ class WPCV_Woo_Civi_Helper {
 
 		// Build options for the Entity Types select.
 		$entity_options['civicrm_exclude'] = __( 'Do not sync to CiviCRM', 'wpcv-woo-civi-integration' );
-		$entity_options['civicrm_contribution'] =  __( 'CiviCRM Contribution', 'wpcv-woo-civi-integration' );
+		$entity_options['civicrm_contribution'] = __( 'CiviCRM Contribution', 'wpcv-woo-civi-integration' );
 
 		/**
 		 * Filters the Entity Types.
@@ -352,7 +350,7 @@ class WPCV_Woo_Civi_Helper {
 			'is_active' => 1,
 			'options' => [
 				'limit' => 0,
-				'sort' => 'weight ASC'
+				'sort' => 'weight ASC',
 			],
 		];
 
@@ -430,7 +428,8 @@ class WPCV_Woo_Civi_Helper {
 		foreach ( $price_sets as $key => $price_set ) {
 
 			// Add renamed ID.
-			$price_set['price_set_id'] = $price_set_id = $price_set['id'];
+			$price_set_id = (int) $price_set['id'];
+			$price_set['price_set_id'] = $price_set_id;
 
 			// Let's give the chained API result array a nicer name.
 			$price_set['price_fields'] = $price_set['api.PriceField.get']['values'];
@@ -446,7 +445,7 @@ class WPCV_Woo_Civi_Helper {
 					$price_field_value['price_field_value_id'] = $value_id;
 
 					// Skip unless matching item.
-					if ( $price_field_id != $price_field_value['price_field_id'] ) {
+					if ( (int) $price_field_id !== (int) $price_field_value['price_field_id'] ) {
 						continue;
 					}
 
@@ -515,6 +514,7 @@ class WPCV_Woo_Civi_Helper {
 		// Build the array for the select with optgroups.
 		foreach ( $price_sets as $price_set_id => $price_set ) {
 			foreach ( $price_set['price_fields'] as $price_field_id => $price_field ) {
+				/* translators: 1: Price Set title, 2: Price Field label */
 				$optgroup_label = sprintf( __( '%1$s (%2$s)', 'wpcv-woo-civi-integration' ), $price_set['title'], $price_field['label'] );
 				$optgroup_content = [];
 				foreach ( $price_field['price_field_values'] as $price_field_value_id => $price_field_value ) {
@@ -544,10 +544,10 @@ class WPCV_Woo_Civi_Helper {
 		// Drill down to find the matching Price Field Value ID.
 		foreach ( $price_sets as $price_set ) {
 			foreach ( $price_set['price_fields'] as $price_field ) {
-				foreach ( $price_field['price_field_values'] as  $price_field_value ) {
+				foreach ( $price_field['price_field_values'] as $price_field_value ) {
 
 					// If it matches, return the enclosing Price Set data array.
-					if ( $price_field_value_id == $price_field_value['id'] ) {
+					if ( (int) $price_field_value_id === (int) $price_field_value['id'] ) {
 						return $price_set;
 					}
 
@@ -576,10 +576,10 @@ class WPCV_Woo_Civi_Helper {
 		// Drill down to find the matching Price Field Value ID.
 		foreach ( $price_sets as $price_set ) {
 			foreach ( $price_set['price_fields'] as $price_field ) {
-				foreach ( $price_field['price_field_values'] as  $price_field_value ) {
+				foreach ( $price_field['price_field_values'] as $price_field_value ) {
 
 					// If it matches, return the enclosing Price Field data array.
-					if ( $price_field_value_id == $price_field_value['id'] ) {
+					if ( (int) $price_field_value_id === (int) $price_field_value['id'] ) {
 						return $price_field;
 					}
 
@@ -608,10 +608,10 @@ class WPCV_Woo_Civi_Helper {
 		// Drill down to find the matching Price Field Value ID.
 		foreach ( $price_sets as $price_set ) {
 			foreach ( $price_set['price_fields'] as $price_field ) {
-				foreach ( $price_field['price_field_values'] as  $price_field_value ) {
+				foreach ( $price_field['price_field_values'] as $price_field_value ) {
 
 					// If it matches, return the Price Field Value data array.
-					if ( $price_field_value_id == $price_field_value['id'] ) {
+					if ( (int) $price_field_value_id === (int) $price_field_value['id'] ) {
 						return $price_field_value;
 					}
 
@@ -857,7 +857,7 @@ class WPCV_Woo_Civi_Helper {
 	 * @since 2.0
 	 *
 	 * @param string $payment_method The WooCommerce payment method.
-	 * @return int $id The CiviCRM payment processor ID.
+	 * @return integer $id The CiviCRM payment processor ID.
 	 */
 	public function payment_instrument_map( $payment_method ) {
 
@@ -997,7 +997,7 @@ class WPCV_Woo_Civi_Helper {
 	 * @since 3.0
 	 *
 	 * @return DateTimeZone $timezone The site timezone.
-	*/
+	 */
 	public function get_site_timezone() {
 
 		/*

--- a/includes/classes/class-woo-civi-helper.php
+++ b/includes/classes/class-woo-civi-helper.php
@@ -629,7 +629,7 @@ class WPCV_Woo_Civi_Helper {
 	 *
 	 * @since 3.0
 	 *
-	 * @return str|bool $decimal_separator The CiviCRM Decimal Separator, or false on failure.
+	 * @return string|bool $decimal_separator The CiviCRM Decimal Separator, or false on failure.
 	 */
 	public function get_decimal_separator() {
 
@@ -687,7 +687,7 @@ class WPCV_Woo_Civi_Helper {
 	 *
 	 * @since 3.0
 	 *
-	 * @return str|bool $thousand_separator The CiviCRM Thousand Separator, or false on failure.
+	 * @return string|bool $thousand_separator The CiviCRM Thousand Separator, or false on failure.
 	 */
 	public function get_thousand_separator() {
 
@@ -745,7 +745,7 @@ class WPCV_Woo_Civi_Helper {
 	 *
 	 * @since 3.0
 	 *
-	 * @param int|float $number The WooCommerce number.
+	 * @param integer|float $number The WooCommerce number.
 	 * @return float $civicrm_number The CiviCRM-compliant number.
 	 */
 	public function get_civicrm_float( $number ) {

--- a/includes/classes/class-woo-civi-membership.php
+++ b/includes/classes/class-woo-civi-membership.php
@@ -34,7 +34,7 @@ class WPCV_Woo_Civi_Membership {
 	 *
 	 * @since 3.0
 	 * @access public
-	 * @var str $meta_key The WooCommerce Product meta key.
+	 * @var string $meta_key The WooCommerce Product meta key.
 	 */
 	public $meta_key = '_woocommerce_civicrm_membership_type_id';
 
@@ -43,7 +43,7 @@ class WPCV_Woo_Civi_Membership {
 	 *
 	 * @since 3.0
 	 * @access public
-	 * @var str $pfv_key The CiviCRM Membership Price Field Value ID meta key.
+	 * @var string $pfv_key The CiviCRM Membership Price Field Value ID meta key.
 	 */
 	public $pfv_key = '_woocommerce_civicrm_membership_pfv_id';
 
@@ -114,7 +114,7 @@ class WPCV_Woo_Civi_Membership {
 	 *
 	 * @since 3.0
 	 *
-	 * @param int $product_id The Product ID.
+	 * @param integer $product_id The Product ID.
 	 * @return int|bool $membership_type_id The Membership Type ID, false otherwise.
 	 */
 	public function get_product_meta( $product_id ) {
@@ -127,8 +127,8 @@ class WPCV_Woo_Civi_Membership {
 	 *
 	 * @since 3.0
 	 *
-	 * @param int $product_id The Product ID.
-	 * @param int $membership_type_id The numeric ID of the Membership Type.
+	 * @param integer $product_id The Product ID.
+	 * @param integer $membership_type_id The numeric ID of the Membership Type.
 	 */
 	public function set_product_meta( $product_id, $membership_type_id ) {
 		update_post_meta( $product_id, $this->meta_key, $membership_type_id );
@@ -139,7 +139,7 @@ class WPCV_Woo_Civi_Membership {
 	 *
 	 * @since 3.0
 	 *
-	 * @param int $product_id The Product ID.
+	 * @param integer $product_id The Product ID.
 	 * @return int|bool $membership_pfv_id The Membership Price Field Value ID, false otherwise.
 	 */
 	public function get_pfv_meta( $product_id ) {
@@ -152,8 +152,8 @@ class WPCV_Woo_Civi_Membership {
 	 *
 	 * @since 3.0
 	 *
-	 * @param int $product_id The Product ID.
-	 * @param int $membership_pfv_id The numeric ID of the Membership Price Field Value.
+	 * @param integer $product_id The Product ID.
+	 * @param integer $membership_pfv_id The numeric ID of the Membership Price Field Value.
 	 */
 	public function set_pfv_meta( $product_id, $membership_pfv_id ) {
 		update_post_meta( $product_id, $this->pfv_key, $membership_pfv_id );
@@ -164,11 +164,11 @@ class WPCV_Woo_Civi_Membership {
 	 *
 	 * @since 3.0
 	 *
-	 * @param array $line_item The array of Line Item data.
+	 * @param array  $line_item The array of Line Item data.
 	 * @param object $item The WooCommerce Item object.
 	 * @param object $product The WooCommerce Product object.
 	 * @param object $order The WooCommerce Order object.
-	 * @param array $params The params to be passed to the CiviCRM API.
+	 * @param array  $params The params to be passed to the CiviCRM API.
 	 * @return array $line_item The modified array of Line Item data.
 	 */
 	public function line_item_filter( $line_item, $item, $product, $order, $params ) {
@@ -402,7 +402,7 @@ class WPCV_Woo_Civi_Membership {
 	 *
 	 * @since 2.4
 	 *
-	 * @param int $id The numeric ID of the CiviCRM Membership Type.
+	 * @param integer $id The numeric ID of the CiviCRM Membership Type.
 	 * @return array|null $membership_type The CiviCRM Membership Type data, or null on failure.
 	 */
 	public function get_membership_type( $id ) {
@@ -625,10 +625,10 @@ class WPCV_Woo_Civi_Membership {
 	 *
 	 * @since 3.0
 	 *
-	 * @param int $loop The position in the loop.
-	 * @param array $variation_data The Product Variation data.
+	 * @param integer $loop The position in the loop.
+	 * @param array   $variation_data The Product Variation data.
 	 * @param WP_Post $variation The WordPress Post data.
-	 * @param string $entity The CiviCRM Entity that this Product Variation is mapped to.
+	 * @param string  $entity The CiviCRM Entity that this Product Variation is mapped to.
 	 */
 	public function attributes_add_markup( $loop, $variation_data, $variation, $entity ) {
 
@@ -672,9 +672,9 @@ class WPCV_Woo_Civi_Membership {
 	 *
 	 * @since 3.0
 	 *
-	 * @param int $loop The position in the loop.
+	 * @param integer              $loop The position in the loop.
 	 * @param WC_Product_Variation $variation The Product Variation object.
-	 * @param str $entity The CiviCRM Entity Type.
+	 * @param string               $entity The CiviCRM Entity Type.
 	 */
 	public function variation_saved( $loop, $variation, $entity ) {
 

--- a/includes/classes/class-woo-civi-membership.php
+++ b/includes/classes/class-woo-civi-membership.php
@@ -672,8 +672,8 @@ class WPCV_Woo_Civi_Membership {
 	 *
 	 * @since 3.0
 	 *
-	 * @param WC_Product_Variation $variation The Product Variation object.
 	 * @param int $loop The position in the loop.
+	 * @param WC_Product_Variation $variation The Product Variation object.
 	 * @param str $entity The CiviCRM Entity Type.
 	 */
 	public function variation_saved( $loop, $variation, $entity ) {

--- a/includes/classes/class-woo-civi-membership.php
+++ b/includes/classes/class-woo-civi-membership.php
@@ -115,7 +115,7 @@ class WPCV_Woo_Civi_Membership {
 	 * @since 3.0
 	 *
 	 * @param integer $product_id The Product ID.
-	 * @return int|bool $membership_type_id The Membership Type ID, false otherwise.
+	 * @return integer|bool $membership_type_id The Membership Type ID, false otherwise.
 	 */
 	public function get_product_meta( $product_id ) {
 		$membership_type_id = get_post_meta( $product_id, $this->meta_key, true );
@@ -140,7 +140,7 @@ class WPCV_Woo_Civi_Membership {
 	 * @since 3.0
 	 *
 	 * @param integer $product_id The Product ID.
-	 * @return int|bool $membership_pfv_id The Membership Price Field Value ID, false otherwise.
+	 * @return integer|bool $membership_pfv_id The Membership Price Field Value ID, false otherwise.
 	 */
 	public function get_pfv_meta( $product_id ) {
 		$membership_pfv_id = get_post_meta( $product_id, $this->pfv_key, true );

--- a/includes/classes/class-woo-civi-order.php
+++ b/includes/classes/class-woo-civi-order.php
@@ -23,7 +23,7 @@ class WPCV_Woo_Civi_Order {
 	 *
 	 * @since 3.0
 	 * @access public
-	 * @var str $is_checkout True if in Checkout, false otherwise.
+	 * @var string $is_checkout True if in Checkout, false otherwise.
 	 */
 	public $is_checkout = false;
 
@@ -88,7 +88,7 @@ class WPCV_Woo_Civi_Order {
 	 * @since 3.0
 	 *
 	 * @param object $order The Order object.
-	 * @param array $data The Order data.
+	 * @param array  $data The Order data.
 	 */
 	public function checkout_create_order( $order, $data ) {
 
@@ -103,22 +103,22 @@ class WPCV_Woo_Civi_Order {
 	 * @since 2.0
 	 * @since 3.0 Renamed from "action_order".
 	 *
-	 * @param int $order_id The Order ID.
-	 * @param array $posted_data The posted data.
-	 * @param object $order The Order object.
+	 * @param integer $order_id The Order ID.
+	 * @param array   $posted_data The posted data.
+	 * @param object  $order The Order object.
 	 */
 	public function checkout_order_processed( $order_id, $posted_data, $order ) {
 
 		// Bail if Order is 'free' (0 amount) and 0 amount setting is enabled.
 		$ignore_zero_orders = WPCV_WCI()->helper->check_yes_no_value( get_option( 'woocommerce_civicrm_ignore_0_amount_orders', false ) );
 		if ( $ignore_zero_orders && $order->get_total() === 0 ) {
-			return false;
+			return;
 		}
 
 		// Add the Contribution record.
 		$contribution = WPCV_WCI()->contribution->create_from_order( $order );
 		if ( $contribution === false ) {
-			return false;
+			return;
 		}
 
 		/**
@@ -128,7 +128,7 @@ class WPCV_Woo_Civi_Order {
 		 *
 		 * @since 3.0
 		 *
-		 * @param int $order_id The Order ID.
+		 * @param integer $order_id The Order ID.
 		 * @param object $order The Order object.
 		 * @param array $contribution The array of Contribution data, or false on failure.
 		 */
@@ -143,8 +143,8 @@ class WPCV_Woo_Civi_Order {
 	 * @since 3.0 Renamed from "save_order".
 	 * @since 3.0 Added $order param.
 	 *
-	 * @param int $order_id The Order ID.
-	 * @param object $order The Order object.
+	 * @param integer $order_id The Order ID.
+	 * @param object  $order The Order object.
 	 */
 	public function order_new( $order_id, $order ) {
 
@@ -166,8 +166,8 @@ class WPCV_Woo_Civi_Order {
 		 *
 		 * @since 3.0
 		 *
-		 * @param int $order_id The Order ID.
-		 * @param object $order The Order object.
+		 * @param integer $order_id The Order ID.
+		 * @param object  $order The Order object.
 		 */
 		do_action( 'wpcv_woo_civi/order/new', $order_id, $order );
 
@@ -178,8 +178,8 @@ class WPCV_Woo_Civi_Order {
 	 *
 	 * @since 3.0
 	 *
-	 * @param int $order_id The Order ID.
-	 * @param object $order The Order object.
+	 * @param integer $order_id The Order ID.
+	 * @param object  $order The Order object.
 	 */
 	public function order_updated( $order_id, $order ) {
 
@@ -192,12 +192,11 @@ class WPCV_Woo_Civi_Order {
 	 * statuses from which the transition to "completed" can be made. Using the
 	 * "woocommerce_valid_order_statuses_for_payment" filter could solve this.
 	 *
-	 *
 	 * @since 3.0
 	 * @since WooCommerce 3.9.0
 	 *
-	 * @param int Order ID
-	 * @param WC_Order Order object
+	 * @param integer $order_id The Order ID.
+	 * @param object  $order The Order object.
 	 */
 	public function order_status_changed_to_paid( $order_id, $order ) {
 
@@ -221,10 +220,10 @@ class WPCV_Woo_Civi_Order {
 	 * @since 3.0 Renamed from "update_order_status".
 	 * @since 3.0 Added $order param.
 	 *
-	 * @param int $order_id The Order ID.
-	 * @param string $old_status The old status.
-	 * @param string $new_status The new status.
-	 * @param object $order The Order object.
+	 * @param integer $order_id The Order ID.
+	 * @param string  $old_status The old status.
+	 * @param string  $new_status The new status.
+	 * @param object  $order The Order object.
 	 */
 	public function order_status_changed( $order_id, $old_status, $new_status, $order ) {
 
@@ -256,7 +255,7 @@ class WPCV_Woo_Civi_Order {
 	 *
 	 * @since 3.0
 	 *
-	 * @param array $contribution The CiviCRM Contribution data.
+	 * @param array  $contribution The CiviCRM Contribution data.
 	 * @param object $order The WooCommerce Order object.
 	 */
 	public function note_add_contribution_created( $contribution, $order ) {
@@ -282,7 +281,7 @@ class WPCV_Woo_Civi_Order {
 	 *
 	 * @since 3.0
 	 *
-	 * @param array $contact The CiviCRM Contact data.
+	 * @param array  $contact The CiviCRM Contact data.
 	 * @param object $order The WooCommerce Order object.
 	 */
 	public function note_add_contact_created( $contact, $order ) {
@@ -304,7 +303,7 @@ class WPCV_Woo_Civi_Order {
 	 *
 	 * @since 3.0
 	 *
-	 * @param array $contact The CiviCRM Contact data.
+	 * @param array  $contact The CiviCRM Contact data.
 	 * @param object $order The WooCommerce Order object.
 	 */
 	public function note_add_contact_updated( $contact, $order ) {

--- a/includes/classes/class-woo-civi-participant.php
+++ b/includes/classes/class-woo-civi-participant.php
@@ -34,7 +34,7 @@ class WPCV_Woo_Civi_Participant {
 	 *
 	 * @since 3.0
 	 * @access public
-	 * @var str $event_key The WooCommerce Product meta key.
+	 * @var string $event_key The WooCommerce Product meta key.
 	 */
 	public $event_key = '_woocommerce_civicrm_event_id';
 
@@ -43,7 +43,7 @@ class WPCV_Woo_Civi_Participant {
 	 *
 	 * @since 3.0
 	 * @access public
-	 * @var str $role_key The WooCommerce Product meta key.
+	 * @var string $role_key The WooCommerce Product meta key.
 	 */
 	public $role_key = '_woocommerce_civicrm_participant_role_id';
 
@@ -52,7 +52,7 @@ class WPCV_Woo_Civi_Participant {
 	 *
 	 * @since 3.0
 	 * @access public
-	 * @var str $pfv_key The CiviCRM Participant Price Field Value ID meta key.
+	 * @var string $pfv_key The CiviCRM Participant Price Field Value ID meta key.
 	 */
 	public $pfv_key = '_woocommerce_civicrm_participant_pfv_id';
 
@@ -123,7 +123,7 @@ class WPCV_Woo_Civi_Participant {
 	 *
 	 * @since 3.0
 	 *
-	 * @param int $product_id The Product ID.
+	 * @param integer $product_id The Product ID.
 	 * @return int|bool $event_id The CiviCRM Event ID, false otherwise.
 	 */
 	public function get_event_meta( $product_id ) {
@@ -136,8 +136,8 @@ class WPCV_Woo_Civi_Participant {
 	 *
 	 * @since 3.0
 	 *
-	 * @param int $product_id The Product ID.
-	 * @param int $event_id The numeric ID of the CiviCRM Event.
+	 * @param integer $product_id The Product ID.
+	 * @param integer $event_id The numeric ID of the CiviCRM Event.
 	 */
 	public function set_event_meta( $product_id, $event_id ) {
 		update_post_meta( $product_id, $this->event_key, (int) $event_id );
@@ -148,7 +148,7 @@ class WPCV_Woo_Civi_Participant {
 	 *
 	 * @since 3.0
 	 *
-	 * @param int $product_id The Product ID.
+	 * @param integer $product_id The Product ID.
 	 * @return int|bool $participant_role_id The Participant Role ID, false otherwise.
 	 */
 	public function get_role_meta( $product_id ) {
@@ -161,8 +161,8 @@ class WPCV_Woo_Civi_Participant {
 	 *
 	 * @since 3.0
 	 *
-	 * @param int $product_id The Product ID.
-	 * @param int $participant_role_id The numeric ID of the Participant Role.
+	 * @param integer $product_id The Product ID.
+	 * @param integer $participant_role_id The numeric ID of the Participant Role.
 	 */
 	public function set_role_meta( $product_id, $participant_role_id ) {
 		update_post_meta( $product_id, $this->role_key, (int) $participant_role_id );
@@ -173,7 +173,7 @@ class WPCV_Woo_Civi_Participant {
 	 *
 	 * @since 3.0
 	 *
-	 * @param int $product_id The Product ID.
+	 * @param integer $product_id The Product ID.
 	 * @return int|bool $participant_pfv_id The Participant Price Field Value ID, false otherwise.
 	 */
 	public function get_pfv_meta( $product_id ) {
@@ -186,8 +186,8 @@ class WPCV_Woo_Civi_Participant {
 	 *
 	 * @since 3.0
 	 *
-	 * @param int $product_id The Product ID.
-	 * @param int $participant_pfv_id The numeric ID of the Participant Price Field Value.
+	 * @param integer $product_id The Product ID.
+	 * @param integer $participant_pfv_id The numeric ID of the Participant Price Field Value.
 	 */
 	public function set_pfv_meta( $product_id, $participant_pfv_id ) {
 		update_post_meta( $product_id, $this->pfv_key, $participant_pfv_id );
@@ -198,11 +198,11 @@ class WPCV_Woo_Civi_Participant {
 	 *
 	 * @since 3.0
 	 *
-	 * @param array $line_item The array of Line Item data.
+	 * @param array  $line_item The array of Line Item data.
 	 * @param object $item The WooCommerce Item object.
 	 * @param object $product The WooCommerce Product object.
 	 * @param object $order The WooCommerce Order object.
-	 * @param array $params The params to be passed to the CiviCRM API.
+	 * @param array  $params The params to be passed to the CiviCRM API.
 	 * @return array $line_item The modified array of Line Item data.
 	 */
 	public function line_item_filter( $line_item, $item, $product, $order, $params ) {
@@ -292,7 +292,8 @@ class WPCV_Woo_Civi_Participant {
 		// Set a descriptive source.
 		// NOTE: CiviCRM populates this with the Payment Method.
 		$line_item_params['source'] = sprintf(
-			__( '%1$s: %2$s' ),
+			/* translators: 1: Source text, 2: Product name */
+			__( '%1$s: %2$s', 'wpcv-woo-civi-integration' ),
 			WPCV_WCI()->source->source_generate(),
 			$args['product']->get_name()
 		);
@@ -404,7 +405,7 @@ class WPCV_Woo_Civi_Participant {
 		$result = civicrm_api( 'Event', 'get', $params );
 
 		// Bail if there's an error.
-		if ( ! empty( $result['is_error'] ) AND $result['is_error'] == 1 ) {
+		if ( ! empty( $result['is_error'] ) && 1 === (int) $result['is_error'] ) {
 			return $events_data;
 		}
 
@@ -458,7 +459,7 @@ class WPCV_Woo_Civi_Participant {
 		$result = civicrm_api( 'Event', 'get', $params );
 
 		// Bail if there's an error.
-		if ( ! empty( $result['is_error'] ) AND $result['is_error'] == 1 ) {
+		if ( ! empty( $result['is_error'] ) && 1 === (int) $result['is_error'] ) {
 			return $event_data;
 		}
 
@@ -480,7 +481,7 @@ class WPCV_Woo_Civi_Participant {
 	 *
 	 * @since 3.0
 	 *
-	 * @param int $limit A number to limit the Event query to.
+	 * @param integer $limit A number to limit the Event query to.
 	 * @return array|boolean $event_data An array of Event data, or false on failure.
 	 */
 	public function get_events( $limit = 25 ) {
@@ -508,7 +509,7 @@ class WPCV_Woo_Civi_Participant {
 		$result = civicrm_api( 'Event', 'get', $params );
 
 		// Bail if there's an error.
-		if ( ! empty( $result['is_error'] ) AND $result['is_error'] == 1 ) {
+		if ( ! empty( $result['is_error'] ) && 1 === (int) $result['is_error'] ) {
 			return $event_data;
 		}
 
@@ -605,7 +606,7 @@ class WPCV_Woo_Civi_Participant {
 		$result = civicrm_api( 'Event', 'getlist', $params );
 
 		// Bail if there's an error.
-		if ( ! empty( $result['is_error'] ) AND $result['is_error'] == 1 ) {
+		if ( ! empty( $result['is_error'] ) && 1 === (int) $result['is_error'] ) {
 			return $event_data;
 		}
 
@@ -646,8 +647,8 @@ class WPCV_Woo_Civi_Participant {
 
 		// First, get Participant Role Option Group ID.
 		$params = [
-			'version' =>'3',
-			'name' =>'participant_role'
+			'version' => 3,
+			'name' => 'participant_role',
 		];
 
 		try {
@@ -675,7 +676,7 @@ class WPCV_Woo_Civi_Participant {
 
 		// Now get the values for that Option Group.
 		$params = [
-			'version' =>'3',
+			'version' => 3,
 			'is_active' => 1,
 			'option_group_id' => $option_group['id'],
 			'options' => [
@@ -766,11 +767,9 @@ class WPCV_Woo_Civi_Participant {
 	}
 
 	/**
-	 * Adds the CiviCRM Event and  Participant Role settings as meta to the Product.
+	 * Adds the CiviCRM Event and Participant Role settings as meta to the Product.
 	 *
 	 * @since 3.0
-	 *
-	 * @param WC_Product $product The Product object.
 	 */
 	public function panel_search_events() {
 
@@ -791,7 +790,7 @@ class WPCV_Woo_Civi_Participant {
 		// Maybe append results.
 		$results = [];
 		if ( ! empty( $events ) ) {
-			foreach( $events AS $event ) {
+			foreach ( $events as $event ) {
 
 				// Add Event Date if present.
 				$title = $event['label'];
@@ -958,10 +957,10 @@ class WPCV_Woo_Civi_Participant {
 	 *
 	 * @since 3.0
 	 *
-	 * @param int $loop The position in the loop.
-	 * @param array $variation_data The Product Variation data.
+	 * @param integer $loop The position in the loop.
+	 * @param array   $variation_data The Product Variation data.
 	 * @param WP_Post $variation The WordPress Post data.
-	 * @param string $entity The CiviCRM Entity that this Product Variation is mapped to.
+	 * @param string  $entity The CiviCRM Entity that this Product Variation is mapped to.
 	 */
 	public function attributes_add_markup( $loop, $variation_data, $variation, $entity ) {
 
@@ -1051,9 +1050,9 @@ class WPCV_Woo_Civi_Participant {
 	 *
 	 * @since 3.0
 	 *
-	 * @param int $loop The position in the loop.
+	 * @param integer              $loop The position in the loop.
 	 * @param WC_Product_Variation $variation The Product Variation object.
-	 * @param str $entity The CiviCRM Entity Type.
+	 * @param string               $entity The CiviCRM Entity Type.
 	 */
 	public function variation_saved( $loop, $variation, $entity ) {
 

--- a/includes/classes/class-woo-civi-participant.php
+++ b/includes/classes/class-woo-civi-participant.php
@@ -1051,8 +1051,8 @@ class WPCV_Woo_Civi_Participant {
 	 *
 	 * @since 3.0
 	 *
-	 * @param WC_Product_Variation $variation The Product Variation object.
 	 * @param int $loop The position in the loop.
+	 * @param WC_Product_Variation $variation The Product Variation object.
 	 * @param str $entity The CiviCRM Entity Type.
 	 */
 	public function variation_saved( $loop, $variation, $entity ) {

--- a/includes/classes/class-woo-civi-participant.php
+++ b/includes/classes/class-woo-civi-participant.php
@@ -124,7 +124,7 @@ class WPCV_Woo_Civi_Participant {
 	 * @since 3.0
 	 *
 	 * @param integer $product_id The Product ID.
-	 * @return int|bool $event_id The CiviCRM Event ID, false otherwise.
+	 * @return integer|bool $event_id The CiviCRM Event ID, false otherwise.
 	 */
 	public function get_event_meta( $product_id ) {
 		$event_id = get_post_meta( $product_id, $this->event_key, true );
@@ -149,7 +149,7 @@ class WPCV_Woo_Civi_Participant {
 	 * @since 3.0
 	 *
 	 * @param integer $product_id The Product ID.
-	 * @return int|bool $participant_role_id The Participant Role ID, false otherwise.
+	 * @return integer|bool $participant_role_id The Participant Role ID, false otherwise.
 	 */
 	public function get_role_meta( $product_id ) {
 		$participant_role_id = get_post_meta( $product_id, $this->role_key, true );
@@ -174,7 +174,7 @@ class WPCV_Woo_Civi_Participant {
 	 * @since 3.0
 	 *
 	 * @param integer $product_id The Product ID.
-	 * @return int|bool $participant_pfv_id The Participant Price Field Value ID, false otherwise.
+	 * @return integer|bool $participant_pfv_id The Participant Price Field Value ID, false otherwise.
 	 */
 	public function get_pfv_meta( $product_id ) {
 		$participant_pfv_id = get_post_meta( $product_id, $this->pfv_key, true );

--- a/includes/classes/class-woo-civi-products-custom.php
+++ b/includes/classes/class-woo-civi-products-custom.php
@@ -377,9 +377,10 @@ class WPCV_Woo_Civi_Products_Custom {
 
 		$classes = [];
 		foreach ( $this->product_names as $type => $name ) {
-			$classes[] = 'show_if_' . $type;
+			$classes[] = esc_attr( 'show_if_' . $type );
 		}
 
+		// phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
 		echo '<div class="options_group ' . implode( ' ', $classes ) . ' clear"></div>';
 
 	}
@@ -427,10 +428,10 @@ class WPCV_Woo_Civi_Products_Custom {
 
 		// Add "show_if" classes to relevant sections.
 		foreach ( $this->product_names as $type => $name ) {
-			echo "\t\t" . "jQuery('#general_product_data .pricing').addClass('show_if_" . $type . "');\n";
+			echo "\t\t" . "jQuery('#general_product_data .pricing').addClass('show_if_{$type}');\n";
 			echo "\t\t" . 'var tax = jQuery("#general_product_data").find("._tax_status_field");' . "\n";
 			echo "\t\t" . 'if (tax.length) {' . "\n";
-			echo "\t\t\t" . "tax.parent().addClass('show_if_" . $type . "');\n";
+			echo "\t\t\t" . "tax.parent().addClass('show_if_{$type}');\n";
 			echo "\t\t" . '}' . "\n";
 		}
 
@@ -554,10 +555,10 @@ class WPCV_Woo_Civi_Products_Custom {
 	 *
 	 * @since 3.0
 	 *
-	 * @param int $pfv_id The possibly found Price Field Value ID.
-	 * @param int $product_id The Product ID.
-	 * @param object $product The WooCommerce Product object.
-	 * @return int $pfv_id The found Price Field Value ID, passed through otherwise.
+	 * @param integer $pfv_id The possibly found Price Field Value ID.
+	 * @param integer $product_id The Product ID.
+	 * @param object  $product The WooCommerce Product object.
+	 * @return integer $pfv_id The found Price Field Value ID, passed through otherwise.
 	 */
 	public function pfv_id_get( $pfv_id, $product_id, $product = null ) {
 
@@ -602,9 +603,9 @@ class WPCV_Woo_Civi_Products_Custom {
 	 *
 	 * @since 3.0
 	 *
-	 * @param str $type The name of the Custom Product Type.
-	 * @param str $key The shorthand for the meta key.
-	 * @return str The requested meta key.
+	 * @param string $type The name of the Custom Product Type.
+	 * @param string $key The shorthand for the meta key.
+	 * @return string The requested meta key.
 	 */
 	public function get_meta_key( $type, $key ) {
 		return $this->product_types_meta[ $type ][ $key ];
@@ -615,9 +616,9 @@ class WPCV_Woo_Civi_Products_Custom {
 	 *
 	 * @since 3.0
 	 *
-	 * @param int $product_id The Product ID.
-	 * @param str $type The name of the WooCommerce Product Type.
-	 * @param str $key The name of the meta key.
+	 * @param integer $product_id The Product ID.
+	 * @param string  $type The name of the WooCommerce Product Type.
+	 * @param string  $key The name of the meta key.
 	 * @return mixed $value The value, false otherwise.
 	 */
 	public function get_meta( $product_id, $type, $key ) {
@@ -633,10 +634,10 @@ class WPCV_Woo_Civi_Products_Custom {
 	 *
 	 * @since 3.0
 	 *
-	 * @param int $product_id The Product ID.
-	 * @param str $type The name of the WooCommerce Product Type.
-	 * @param str $key The name of the meta key.
-	 * @param mixed $value The value to save.
+	 * @param integer $product_id The Product ID.
+	 * @param string  $type The name of the WooCommerce Product Type.
+	 * @param string  $key The name of the meta key.
+	 * @param mixed   $value The value to save.
 	 */
 	public function set_meta( $product_id, $type, $key, $value ) {
 		if ( ! empty( $this->product_types_meta[ $type ][ $key ] ) ) {
@@ -649,7 +650,7 @@ class WPCV_Woo_Civi_Products_Custom {
 	 *
 	 * @since 3.0
 	 *
-	 * @param bool $skip The possibly set "skip" flag.
+	 * @param bool   $skip The possibly set "skip" flag.
 	 * @param object $item The WooCommerce Item object.
 	 * @param object $product The WooCommerce Product object.
 	 * @param string $product_type The WooCommerce Product Type.
@@ -672,11 +673,11 @@ class WPCV_Woo_Civi_Products_Custom {
 	 *
 	 * @since 3.0
 	 *
-	 * @param array $line_item The array of Line Item data.
+	 * @param array  $line_item The array of Line Item data.
 	 * @param object $item The WooCommerce Item object.
 	 * @param object $product The WooCommerce Product object.
 	 * @param object $order The WooCommerce Order object.
-	 * @param array $params The params to be passed to the CiviCRM API.
+	 * @param array  $params The params to be passed to the CiviCRM API.
 	 * @return array $line_item The modified array of Line Item data.
 	 */
 	public function line_item_filter( $line_item, $item, $product, $order, $params ) {
@@ -689,13 +690,13 @@ class WPCV_Woo_Civi_Products_Custom {
 
 		// Send to relevant method.
 		switch ( $product_type ) {
-			case 'civicrm_contribution' :
+			case 'civicrm_contribution':
 				$line_item = $this->line_item_contribution_filter( $line_item, $item, $product, $order, $params );
 				break;
-			case 'civicrm_membership' :
+			case 'civicrm_membership':
 				$line_item = $this->line_item_membership_filter( $line_item, $item, $product, $order, $params );
 				break;
-			case 'civicrm_participant' :
+			case 'civicrm_participant':
 				$line_item = $this->line_item_participant_filter( $line_item, $item, $product, $order, $params );
 				break;
 		}
@@ -709,11 +710,11 @@ class WPCV_Woo_Civi_Products_Custom {
 	 *
 	 * @since 3.0
 	 *
-	 * @param array $line_item The array of Line Item data.
+	 * @param array  $line_item The array of Line Item data.
 	 * @param object $item The WooCommerce Item object.
 	 * @param object $product The WooCommerce Product object.
 	 * @param object $order The WooCommerce Order object.
-	 * @param array $params The params to be passed to the CiviCRM API.
+	 * @param array  $params The params to be passed to the CiviCRM API.
 	 * @return array $line_item The modified array of Line Item data.
 	 */
 	public function line_item_contribution_filter( $line_item, $item, $product, $order, $params ) {
@@ -784,11 +785,11 @@ class WPCV_Woo_Civi_Products_Custom {
 	 *
 	 * @since 3.0
 	 *
-	 * @param array $line_item The array of Line Item data.
+	 * @param array  $line_item The array of Line Item data.
 	 * @param object $item The WooCommerce Item object.
 	 * @param object $product The WooCommerce Product object.
 	 * @param object $order The WooCommerce Order object.
-	 * @param array $params The params to be passed to the CiviCRM API.
+	 * @param array  $params The params to be passed to the CiviCRM API.
 	 * @return array $line_item The modified array of Line Item data.
 	 */
 	public function line_item_membership_filter( $line_item, $item, $product, $order, $params ) {
@@ -850,11 +851,11 @@ class WPCV_Woo_Civi_Products_Custom {
 	 *
 	 * @since 3.0
 	 *
-	 * @param array $line_item The array of Line Item data.
+	 * @param array  $line_item The array of Line Item data.
 	 * @param object $item The WooCommerce Item object.
 	 * @param object $product The WooCommerce Product object.
 	 * @param object $order The WooCommerce Order object.
-	 * @param array $params The params to be passed to the CiviCRM API.
+	 * @param array  $params The params to be passed to the CiviCRM API.
 	 * @return array $line_item The modified array of Line Item data.
 	 */
 	public function line_item_participant_filter( $line_item, $item, $product, $order, $params ) {
@@ -918,10 +919,10 @@ class WPCV_Woo_Civi_Products_Custom {
 	 *
 	 * @since 3.0
 	 *
-	 * @param str $entity_type The possibly found Entity Type.
-	 * @param int $product_id The Product ID.
-	 * @param object $product The WooCommerce Product object.
-	 * @return str $entity_type The found Entity Type, passed through otherwise.
+	 * @param string  $entity_type The possibly found Entity Type.
+	 * @param integer $product_id The Product ID.
+	 * @param object  $product The WooCommerce Product object.
+	 * @return string $entity_type The found Entity Type, passed through otherwise.
 	 */
 	public function entity_type_get( $entity_type, $product_id, $product = null ) {
 
@@ -956,10 +957,10 @@ class WPCV_Woo_Civi_Products_Custom {
 	 *
 	 * @since 3.0
 	 *
-	 * @param int $financial_type_id The possibly found Financial Type ID.
-	 * @param int $product_id The Product ID.
-	 * @param object $product The WooCommerce Product object.
-	 * @return int $financial_type_id The found Financial Type ID, passed through otherwise.
+	 * @param integer $financial_type_id The possibly found Financial Type ID.
+	 * @param integer $product_id The Product ID.
+	 * @param object  $product The WooCommerce Product object.
+	 * @return integer $financial_type_id The found Financial Type ID, passed through otherwise.
 	 */
 	public function financial_type_id_get( $financial_type_id, $product_id, $product = null ) {
 
@@ -1000,8 +1001,8 @@ class WPCV_Woo_Civi_Products_Custom {
 	 *
 	 * @since 3.0
 	 *
-	 * @param object $product The WooCommerce Product object.
-	 * @param int $financial_type_id The Financial Type ID.
+	 * @param object  $product The WooCommerce Product object.
+	 * @param integer $financial_type_id The Financial Type ID.
 	 */
 	public function financial_type_id_save( $product, $financial_type_id ) {
 

--- a/includes/classes/class-woo-civi-products-variable.php
+++ b/includes/classes/class-woo-civi-products-variable.php
@@ -136,7 +136,7 @@ class WPCV_Woo_Civi_Products_Variable {
 	public function tab_add( $tabs ) {
 
 		$tabs['civicrm_variable'] = [
-			'label' => __( 'CiviCRM Settings', 'wpcv-woo-civi-integration' ),
+			'label' => __( 'CiviCRM Entity', 'wpcv-woo-civi-integration' ),
 			'target' => 'civicrm_variable',
 			'class' => [
 				'show_if_variable',

--- a/includes/classes/class-woo-civi-products-variable.php
+++ b/includes/classes/class-woo-civi-products-variable.php
@@ -23,7 +23,7 @@ class WPCV_Woo_Civi_Products_Variable {
 	 *
 	 * @since 3.0
 	 * @access public
-	 * @var str $entity_key The CiviCRM Entity Type meta key.
+	 * @var string $entity_key The CiviCRM Entity Type meta key.
 	 */
 	public $entity_key = '_wpcv_wci_variable_civicrm_entity_type';
 
@@ -237,8 +237,8 @@ class WPCV_Woo_Civi_Products_Variable {
 	 *
 	 * @since 3.0
 	 *
-	 * @param int $loop The position in the loop.
-	 * @param array $variation_data The Variation data.
+	 * @param integer $loop The position in the loop.
+	 * @param array   $variation_data The Variation data.
 	 * @param WP_Post $variation The WordPress Post data.
 	 */
 	public function variation_attributes_render( $loop, $variation_data, $variation ) {
@@ -286,7 +286,7 @@ class WPCV_Woo_Civi_Products_Variable {
 	 * @since 3.0
 	 *
 	 * @param WC_Product_Variation $variation The Product Variation object.
-	 * @param int $loop The position in the loop.
+	 * @param integer              $loop The position in the loop.
 	 */
 	public function variation_saved( $variation, $loop ) {
 
@@ -296,7 +296,7 @@ class WPCV_Woo_Civi_Products_Variable {
 		 * @since 3.0
 		 *
 		 * @param WC_Product_Variation $variation The Product Variation object.
-		 * @param int $loop The position in the loop.
+		 * @param integer $loop The position in the loop.
 		 */
 		do_action( 'wpcv_woo_civi/product/variation/attributes/saved/before', $variation, $loop );
 
@@ -347,8 +347,8 @@ class WPCV_Woo_Civi_Products_Variable {
 		 * @since 3.0
 		 *
 		 * @param WC_Product_Variation $variation The Product Variation object.
-		 * @param int $loop The position in the loop.
-		 * @param str $entity_type The CiviCRM Entity Type.
+		 * @param integer $loop The position in the loop.
+		 * @param string $entity_type The CiviCRM Entity Type.
 		 */
 		do_action( 'wpcv_woo_civi/product/variation/attributes/saved/after', $variation, $loop, $entity_type );
 
@@ -359,7 +359,7 @@ class WPCV_Woo_Civi_Products_Variable {
 	 *
 	 * @since 3.0
 	 *
-	 * @param bool $skip The possibly set "skip" flag.
+	 * @param bool   $skip The possibly set "skip" flag.
 	 * @param object $item The WooCommerce Item object.
 	 * @param object $product The WooCommerce Product object.
 	 * @param string $product_type The WooCommerce Product Type.
@@ -382,11 +382,11 @@ class WPCV_Woo_Civi_Products_Variable {
 	 *
 	 * @since 3.0
 	 *
-	 * @param array $line_item The array of Line Item data.
+	 * @param array  $line_item The array of Line Item data.
 	 * @param object $item The WooCommerce Item object.
 	 * @param object $product The WooCommerce Product object.
 	 * @param object $order The WooCommerce Order object.
-	 * @param array $params The params to be passed to the CiviCRM API.
+	 * @param array  $params The params to be passed to the CiviCRM API.
 	 * @return array $line_item The modified array of Line Item data.
 	 */
 	public function line_item_filter( $line_item, $item, $product, $order, $params ) {
@@ -402,13 +402,13 @@ class WPCV_Woo_Civi_Products_Variable {
 
 		// Send to relevant method.
 		switch ( $entity_type ) {
-			case 'civicrm_contribution' :
+			case 'civicrm_contribution':
 				$line_item = $this->line_item_contribution_filter( $line_item, $item, $product, $order, $params );
 				break;
-			case 'civicrm_membership' :
+			case 'civicrm_membership':
 				$line_item = $this->line_item_membership_filter( $line_item, $item, $product, $order, $params );
 				break;
-			case 'civicrm_participant' :
+			case 'civicrm_participant':
 				$line_item = $this->line_item_participant_filter( $line_item, $item, $product, $order, $params );
 				break;
 		}
@@ -422,11 +422,11 @@ class WPCV_Woo_Civi_Products_Variable {
 	 *
 	 * @since 3.0
 	 *
-	 * @param array $line_item The array of Line Item data.
+	 * @param array  $line_item The array of Line Item data.
 	 * @param object $item The WooCommerce Item object.
 	 * @param object $product The WooCommerce Product object.
 	 * @param object $order The WooCommerce Order object.
-	 * @param array $params The params to be passed to the CiviCRM API.
+	 * @param array  $params The params to be passed to the CiviCRM API.
 	 * @return array $line_item The modified array of Line Item data.
 	 */
 	public function line_item_contribution_filter( $line_item, $item, $product, $order, $params ) {
@@ -497,11 +497,11 @@ class WPCV_Woo_Civi_Products_Variable {
 	 *
 	 * @since 3.0
 	 *
-	 * @param array $line_item The array of Line Item data.
+	 * @param array  $line_item The array of Line Item data.
 	 * @param object $item The WooCommerce Item object.
 	 * @param object $product The WooCommerce Product object.
 	 * @param object $order The WooCommerce Order object.
-	 * @param array $params The params to be passed to the CiviCRM API.
+	 * @param array  $params The params to be passed to the CiviCRM API.
 	 * @return array $line_item The modified array of Line Item data.
 	 */
 	public function line_item_membership_filter( $line_item, $item, $product, $order, $params ) {
@@ -563,11 +563,11 @@ class WPCV_Woo_Civi_Products_Variable {
 	 *
 	 * @since 3.0
 	 *
-	 * @param array $line_item The array of Line Item data.
+	 * @param array  $line_item The array of Line Item data.
 	 * @param object $item The WooCommerce Item object.
 	 * @param object $product The WooCommerce Product object.
 	 * @param object $order The WooCommerce Order object.
-	 * @param array $params The params to be passed to the CiviCRM API.
+	 * @param array  $params The params to be passed to the CiviCRM API.
 	 * @return array $line_item The modified array of Line Item data.
 	 */
 	public function line_item_participant_filter( $line_item, $item, $product, $order, $params ) {
@@ -635,9 +635,9 @@ class WPCV_Woo_Civi_Products_Variable {
 	 *
 	 * @since 3.0
 	 *
-	 * @param str $type The type of Product Variation.
-	 * @param str $key The shorthand for the meta key.
-	 * @return str The requested meta key.
+	 * @param string $type The type of Product Variation.
+	 * @param string $key The shorthand for the meta key.
+	 * @return string The requested meta key.
 	 */
 	public function get_meta_key( $type, $key ) {
 
@@ -662,9 +662,9 @@ class WPCV_Woo_Civi_Products_Variable {
 	 *
 	 * @since 3.0
 	 *
-	 * @param int $product_id The Product ID.
-	 * @param str $type The type of Product Variation.
-	 * @param str $key The name of the meta key.
+	 * @param integer $product_id The Product ID.
+	 * @param string  $type The type of Product Variation.
+	 * @param string  $key The name of the meta key.
 	 * @return mixed $value The value, false otherwise.
 	 */
 	public function get_meta( $product_id, $type, $key ) {
@@ -680,10 +680,10 @@ class WPCV_Woo_Civi_Products_Variable {
 	 *
 	 * @since 3.0
 	 *
-	 * @param int $product_id The Product ID.
-	 * @param str $type The type of Product Variation.
-	 * @param str $key The name of the meta key.
-	 * @param mixed $value The value to save.
+	 * @param integer $product_id The Product ID.
+	 * @param string  $type The type of Product Variation.
+	 * @param string  $key The name of the meta key.
+	 * @param mixed   $value The value to save.
 	 */
 	public function set_meta( $product_id, $type, $key, $value ) {
 		if ( ! empty( $this->product_variation_meta[ $type ][ $key ] ) ) {
@@ -734,10 +734,10 @@ class WPCV_Woo_Civi_Products_Variable {
 	 *
 	 * @since 3.0
 	 *
-	 * @param str $entity_type The possibly found Entity Type.
-	 * @param int $product_id The Product ID.
-	 * @param object $product The WooCommerce Product object.
-	 * @return str $entity_type The found Entity Type, passed through otherwise.
+	 * @param string  $entity_type The possibly found Entity Type.
+	 * @param integer $product_id The Product ID.
+	 * @param object  $product The WooCommerce Product object.
+	 * @return string $entity_type The found Entity Type, passed through otherwise.
 	 */
 	public function entity_type_get( $entity_type, $product_id, $product = null ) {
 
@@ -782,7 +782,7 @@ class WPCV_Woo_Civi_Products_Variable {
 	 * @since 3.0
 	 *
 	 * @param object $product The WooCommerce Product object.
-	 * @param str $entity_type The CiviCRM Entity Type.
+	 * @param string $entity_type The CiviCRM Entity Type.
 	 */
 	public function entity_type_save( $product, $entity_type ) {
 
@@ -818,10 +818,10 @@ class WPCV_Woo_Civi_Products_Variable {
 	 *
 	 * @since 3.0
 	 *
-	 * @param int $financial_type_id The possibly found Financial Type ID.
-	 * @param int $product_id The Product ID.
-	 * @param object $product The WooCommerce Product object.
-	 * @return int $financial_type_id The found Financial Type ID, passed through otherwise.
+	 * @param integer $financial_type_id The possibly found Financial Type ID.
+	 * @param integer $product_id The Product ID.
+	 * @param object  $product The WooCommerce Product object.
+	 * @return integer $financial_type_id The found Financial Type ID, passed through otherwise.
 	 */
 	public function financial_type_id_get( $financial_type_id, $product_id, $product = null ) {
 
@@ -866,8 +866,8 @@ class WPCV_Woo_Civi_Products_Variable {
 	 *
 	 * @since 3.0
 	 *
-	 * @param object $product The WooCommerce Product object.
-	 * @param int $financial_type_id The Financial Type ID.
+	 * @param object  $product The WooCommerce Product object.
+	 * @param integer $financial_type_id The Financial Type ID.
 	 */
 	public function financial_type_id_save( $product, $financial_type_id ) {
 

--- a/includes/classes/class-woo-civi-products.php
+++ b/includes/classes/class-woo-civi-products.php
@@ -23,7 +23,7 @@ class WPCV_Woo_Civi_Products {
 	 *
 	 * @since 3.0
 	 * @access public
-	 * @var str $entity_key The CiviCRM Entity Type meta key.
+	 * @var string $entity_key The CiviCRM Entity Type meta key.
 	 */
 	public $entity_key = '_woocommerce_civicrm_entity_type';
 
@@ -32,7 +32,7 @@ class WPCV_Woo_Civi_Products {
 	 *
 	 * @since 3.0
 	 * @access public
-	 * @var str $financial_type_key The CiviCRM Financial Type ID meta key.
+	 * @var string $financial_type_key The CiviCRM Financial Type ID meta key.
 	 */
 	public $financial_type_key = '_woocommerce_civicrm_financial_type_id';
 
@@ -41,7 +41,7 @@ class WPCV_Woo_Civi_Products {
 	 *
 	 * @since 3.0
 	 * @access public
-	 * @var str $pfv_key The CiviCRM Contribution Price Field Value ID meta key.
+	 * @var string $pfv_key The CiviCRM Contribution Price Field Value ID meta key.
 	 */
 	public $pfv_key = '_woocommerce_civicrm_contribution_pfv_id';
 
@@ -50,7 +50,7 @@ class WPCV_Woo_Civi_Products {
 	 *
 	 * @since 3.0
 	 * @access public
-	 * @var str $purchase_activity The array of Purchase Activity Details.
+	 * @var string $purchase_activity The array of Purchase Activity Details.
 	 */
 	public $purchase_activity = [];
 
@@ -120,7 +120,7 @@ class WPCV_Woo_Civi_Products {
 	 *
 	 * @since 3.0
 	 *
-	 * @param int $product_id The Product ID.
+	 * @param integer $product_id The Product ID.
 	 * @return str|bool $entity_type The CiviCRM Entity Type, false otherwise.
 	 */
 	public function get_entity_meta( $product_id ) {
@@ -133,8 +133,8 @@ class WPCV_Woo_Civi_Products {
 	 *
 	 * @since 3.0
 	 *
-	 * @param int $product_id The Product ID.
-	 * @param str $entity_type The CiviCRM Entity Type.
+	 * @param integer $product_id The Product ID.
+	 * @param string  $entity_type The CiviCRM Entity Type.
 	 */
 	public function set_entity_meta( $product_id, $entity_type ) {
 		update_post_meta( $product_id, $this->entity_key, $entity_type );
@@ -145,7 +145,7 @@ class WPCV_Woo_Civi_Products {
 	 *
 	 * @since 3.0
 	 *
-	 * @param int $product_id The Product ID.
+	 * @param integer $product_id The Product ID.
 	 * @return int|bool $financial_type_id The Financial Type ID, false otherwise.
 	 */
 	public function get_product_meta( $product_id ) {
@@ -158,8 +158,8 @@ class WPCV_Woo_Civi_Products {
 	 *
 	 * @since 3.0
 	 *
-	 * @param int $product_id The Product ID.
-	 * @param int $financial_type_id The numeric ID of the Financial Type.
+	 * @param integer $product_id The Product ID.
+	 * @param integer $financial_type_id The numeric ID of the Financial Type.
 	 */
 	public function set_product_meta( $product_id, $financial_type_id ) {
 		update_post_meta( $product_id, $this->financial_type_key, $financial_type_id );
@@ -170,7 +170,7 @@ class WPCV_Woo_Civi_Products {
 	 *
 	 * @since 3.0
 	 *
-	 * @param int $product_id The Product ID.
+	 * @param integer $product_id The Product ID.
 	 * @return int|bool $contribution_pfv_id The Contribution Price Field Value ID, false otherwise.
 	 */
 	public function get_pfv_meta( $product_id ) {
@@ -183,8 +183,8 @@ class WPCV_Woo_Civi_Products {
 	 *
 	 * @since 3.0
 	 *
-	 * @param int $product_id The Product ID.
-	 * @param int $contribution_pfv_id The numeric ID of the Contribution Price Field Value.
+	 * @param integer $product_id The Product ID.
+	 * @param integer $contribution_pfv_id The numeric ID of the Contribution Price Field Value.
 	 */
 	public function set_pfv_meta( $product_id, $contribution_pfv_id ) {
 		update_post_meta( $product_id, $this->pfv_key, $contribution_pfv_id );
@@ -195,7 +195,7 @@ class WPCV_Woo_Civi_Products {
 	 *
 	 * @since 3.0
 	 *
-	 * @param array $params The existing array of params for the CiviCRM API.
+	 * @param array  $params The existing array of params for the CiviCRM API.
 	 * @param object $order The Order object.
 	 * @return array $params The modified array of params for the CiviCRM API.
 	 */
@@ -224,9 +224,9 @@ class WPCV_Woo_Civi_Products {
 	 * @since 2.2 Line Items added to CiviCRM Contribution.
 	 * @since 3.0 Logic moved to this method.
 	 *
-	 * @param array $params The existing array of params for the CiviCRM API.
+	 * @param array  $params The existing array of params for the CiviCRM API.
 	 * @param object $order The Order object.
-	 * @param array $items The array of Items in the Order.
+	 * @param array  $items The array of Items in the Order.
 	 * @return array $params The modified array of params for the CiviCRM API.
 	 */
 	public function items_build_for_order( $params, $order, $items ) {
@@ -334,6 +334,7 @@ class WPCV_Woo_Civi_Products {
 
 			// Store the Purchase Activity Details.
 			$this->purchase_activity[] = sprintf(
+				/* translators: 1: Product Name, 2: Quantity */
 				__( '%1$s x %2$s', 'wpcv-woo-civi-integration' ),
 				$product->get_name(),
 				$item->get_quantity()
@@ -396,8 +397,8 @@ class WPCV_Woo_Civi_Products {
 		 *
 		 * @since 3.0
 		 *
-		 * @param int Numeric 0 because we are querying the Entity.
-		 * @param int $product_id The WooCommerce Product ID.
+		 * @param integer Numeric 0 because we are querying the Entity.
+		 * @param integer $product_id The WooCommerce Product ID.
 		 * @param object $product The WooCommerce Product object.
 		 */
 		$entity = apply_filters( 'wpcv_woo_civi/product/query/entity_type', '', $product->get_id(), $product );
@@ -407,7 +408,7 @@ class WPCV_Woo_Civi_Products {
 		 *
 		 * @since 3.0
 		 *
-		 * @param bool $skip False because we assume that Products should not be skipped.
+		 * @param bool   $skip False because we assume that Products should not be skipped.
 		 * @param object $item The WooCommerce Item object.
 		 * @param object $product The WooCommerce Product object.
 		 * @param string $product_type The WooCommerce Product Type.
@@ -424,7 +425,7 @@ class WPCV_Woo_Civi_Products {
 	 *
 	 * @since 3.0
 	 *
-	 * @param bool $skip The possibly set "skip" flag.
+	 * @param bool   $skip The possibly set "skip" flag.
 	 * @param object $item The WooCommerce Item object.
 	 * @param object $product The WooCommerce Product object.
 	 * @param string $product_type The WooCommerce Product Type.
@@ -447,7 +448,7 @@ class WPCV_Woo_Civi_Products {
 	 *
 	 * @since 3.0
 	 *
-	 * @param array $params The existing array of params for the CiviCRM API.
+	 * @param array  $params The existing array of params for the CiviCRM API.
 	 * @param object $order The Order object.
 	 * @return array $params The modified array of params for the CiviCRM API.
 	 */
@@ -492,7 +493,7 @@ class WPCV_Woo_Civi_Products {
 			$trace = $e->getTraceAsString();
 			error_log( print_r( [
 				'method' => __METHOD__,
-				'message' =>  $message,
+				'message' => $message,
 				'params' => $params,
 				'backtrace' => $trace,
 			], true ) );
@@ -516,7 +517,7 @@ class WPCV_Woo_Civi_Products {
 					'unit_price' => $shipping_cost,
 					'label' => 'Shipping',
 					'financial_type_id' => $default_financial_type_shipping_id,
-				]
+				],
 			],
 		];
 
@@ -602,7 +603,7 @@ class WPCV_Woo_Civi_Products {
 		}
 
 		// Make human-readable.
-		$str =  implode( ', ', $this->purchase_activity );
+		$str = implode( ', ', $this->purchase_activity );
 
 		return $str;
 
@@ -620,9 +621,10 @@ class WPCV_Woo_Civi_Products {
 	 *
 	 * @since 3.0
 	 *
-	 * @param array $params The params to be passed to the CiviCRM API.
+	 * @param array  $params The params to be passed to the CiviCRM API.
 	 * @param object $order The WooCommerce Order object.
-	 * @param array $contribution The CiviCRM Contribution data.
+	 * @param array  $contribution The CiviCRM Contribution data.
+	 * @return array $params The modified params to be passed to the CiviCRM API.
 	 */
 	public function payment_total_filter( $params, $order, $contribution ) {
 
@@ -685,9 +687,10 @@ class WPCV_Woo_Civi_Products {
 	 *
 	 * @since 3.0
 	 *
-	 * @param array $params The params to be passed to the CiviCRM API.
+	 * @param array  $params The params to be passed to the CiviCRM API.
 	 * @param object $order The WooCommerce Order object.
-	 * @param array $contribution The CiviCRM Contribution data.
+	 * @param array  $contribution The CiviCRM Contribution data.
+	 * @return array $params The modifed params to be passed to the CiviCRM API.
 	 */
 	public function items_get_for_payment( $params, $order, $contribution ) {
 
@@ -729,7 +732,7 @@ class WPCV_Woo_Civi_Products {
 	 *
 	 * @since 3.0
 	 *
-	 * @param int $contribution_id The numeric ID of the CiviCRM Contribution.
+	 * @param integer $contribution_id The numeric ID of the CiviCRM Contribution.
 	 * @return array $line_items The CiviCRM Line Item data, or empty on failure.
 	 */
 	public function items_get_by_contribution_id( $contribution_id ) {
@@ -754,7 +757,7 @@ class WPCV_Woo_Civi_Products {
 		$result = civicrm_api( 'LineItem', 'get', $params );
 
 		// Bail if there's an error.
-		if ( ! empty( $result['is_error'] ) AND $result['is_error'] == 1 ) {
+		if ( ! empty( $result['is_error'] ) && 1 === (int) $result['is_error'] ) {
 
 			// Write to CiviCRM log.
 			CRM_Core_Error::debug_log_message( __( 'Error trying to find Line Items by Contribution ID', 'wpcv-woo-civi-integration' ) );
@@ -773,7 +776,7 @@ class WPCV_Woo_Civi_Products {
 
 		}
 
- 		// The result set is what we want.
+		// The result set is what we want.
 		$line_items = [];
 		if ( ! empty( $result['values'] ) ) {
 			$line_items = $result['values'];
@@ -880,10 +883,10 @@ class WPCV_Woo_Civi_Products {
 	 *
 	 * @since 3.0
 	 *
-	 * @param str $entity_type The possibly found Entity Type.
-	 * @param int $product_id The Product ID.
-	 * @param object $product The WooCommerce Product object.
-	 * @return str $entity_type The found Entity Type, passed through otherwise.
+	 * @param string  $entity_type The possibly found Entity Type.
+	 * @param integer $product_id The Product ID.
+	 * @param object  $product The WooCommerce Product object.
+	 * @return string $entity_type The found Entity Type, passed through otherwise.
 	 */
 	public function entity_type_get( $entity_type, $product_id, $product = null ) {
 
@@ -922,7 +925,7 @@ class WPCV_Woo_Civi_Products {
 	 * @since 3.0
 	 *
 	 * @param object $product The WooCommerce Product object.
-	 * @param str $entity_type The CiviCRM Entity Type.
+	 * @param string $entity_type The CiviCRM Entity Type.
 	 */
 	public function entity_type_save( $product, $entity_type ) {
 
@@ -948,10 +951,10 @@ class WPCV_Woo_Civi_Products {
 	 *
 	 * @since 3.0
 	 *
-	 * @param int $financial_type_id The possibly found Financial Type ID.
-	 * @param int $product_id The Product ID.
-	 * @param object $product The WooCommerce Product object.
-	 * @return int $financial_type_id The found Financial Type ID, passed through otherwise.
+	 * @param integer $financial_type_id The possibly found Financial Type ID.
+	 * @param integer $product_id The Product ID.
+	 * @param object  $product The WooCommerce Product object.
+	 * @return integer $financial_type_id The found Financial Type ID, passed through otherwise.
 	 */
 	public function financial_type_id_get( $financial_type_id, $product_id, $product = null ) {
 
@@ -993,8 +996,8 @@ class WPCV_Woo_Civi_Products {
 	 *
 	 * @since 3.0
 	 *
-	 * @param object $product The WooCommerce Product object.
-	 * @param int $financial_type_id The Financial Type ID.
+	 * @param object  $product The WooCommerce Product object.
+	 * @param integer $financial_type_id The Financial Type ID.
 	 */
 	public function financial_type_id_save( $product, $financial_type_id ) {
 
@@ -1020,10 +1023,10 @@ class WPCV_Woo_Civi_Products {
 	 *
 	 * @since 3.0
 	 *
-	 * @param int $pfv_id The possibly found Price Field Value ID.
-	 * @param int $product_id The Product ID.
-	 * @param object $product The WooCommerce Product object.
-	 * @return int $pfv_id The found Price Field Value ID, passed through otherwise.
+	 * @param integer $pfv_id The possibly found Price Field Value ID.
+	 * @param integer $product_id The Product ID.
+	 * @param object  $product The WooCommerce Product object.
+	 * @return integer $pfv_id The found Price Field Value ID, passed through otherwise.
 	 */
 	public function pfv_id_get( $pfv_id, $product_id, $product = null ) {
 

--- a/includes/classes/class-woo-civi-products.php
+++ b/includes/classes/class-woo-civi-products.php
@@ -121,7 +121,7 @@ class WPCV_Woo_Civi_Products {
 	 * @since 3.0
 	 *
 	 * @param integer $product_id The Product ID.
-	 * @return str|bool $entity_type The CiviCRM Entity Type, false otherwise.
+	 * @return string|bool $entity_type The CiviCRM Entity Type, false otherwise.
 	 */
 	public function get_entity_meta( $product_id ) {
 		$entity_type = get_post_meta( $product_id, $this->entity_key, true );
@@ -146,7 +146,7 @@ class WPCV_Woo_Civi_Products {
 	 * @since 3.0
 	 *
 	 * @param integer $product_id The Product ID.
-	 * @return int|bool $financial_type_id The Financial Type ID, false otherwise.
+	 * @return integer|bool $financial_type_id The Financial Type ID, false otherwise.
 	 */
 	public function get_product_meta( $product_id ) {
 		$financial_type_id = get_post_meta( $product_id, $this->financial_type_key, true );
@@ -171,7 +171,7 @@ class WPCV_Woo_Civi_Products {
 	 * @since 3.0
 	 *
 	 * @param integer $product_id The Product ID.
-	 * @return int|bool $contribution_pfv_id The Contribution Price Field Value ID, false otherwise.
+	 * @return integer|bool $contribution_pfv_id The Contribution Price Field Value ID, false otherwise.
 	 */
 	public function get_pfv_meta( $product_id ) {
 		$contribution_pfv_id = get_post_meta( $product_id, $this->pfv_key, true );

--- a/includes/classes/class-woo-civi-settings-network.php
+++ b/includes/classes/class-woo-civi-settings-network.php
@@ -23,7 +23,7 @@ class WPCV_Woo_Civi_Settings_Network {
 	 *
 	 * @since 3.0
 	 * @access public
-	 * @var str $settings_key The Network Settings key.
+	 * @var string $settings_key The Network Settings key.
 	 */
 	public $settings_key = 'woocommerce_civicrm_network_settings';
 
@@ -206,7 +206,7 @@ class WPCV_Woo_Civi_Settings_Network {
 	public function network_settings_save() {
 
 		if ( ! wp_verify_nonce( filter_input( INPUT_POST, 'woocommerce-civicrm-settings', FILTER_SANITIZE_STRING ), 'woocommerce-civicrm-settings' ) ) {
-			wp_die( __( 'Cheating uh?', 'wpcv-woo-civi-integration' ) );
+			wp_die( esc_html__( 'Cheating uh?', 'wpcv-woo-civi-integration' ) );
 		}
 
 		if ( ! empty( $_POST[ $this->settings_key ]['wc_blog_id'] ) ) {

--- a/includes/classes/class-woo-civi-settings-products.php
+++ b/includes/classes/class-woo-civi-settings-products.php
@@ -367,7 +367,7 @@ class WPCV_Woo_Civi_Settings_Products {
 	 * @since 3.0
 	 *
 	 * @param int $post_id The WordPress Post ID.
-	 * @param string $$product_type The WooCommerce Product Type.
+	 * @param string $product_type The WooCommerce Product Type.
 	 * @param string $entity_type The CiviCRM Entity Type.
 	 * @param int $financial_type_id The CiviCRM Financial Type ID.
 	 * @param int $pfv_id The CiviCRM Price Field Value ID.

--- a/includes/classes/class-woo-civi-settings-products.php
+++ b/includes/classes/class-woo-civi-settings-products.php
@@ -86,7 +86,7 @@ class WPCV_Woo_Civi_Settings_Products {
 
 		$classes = [];
 		$product_types_with_panel = get_option( 'woocommerce_civicrm_product_types_with_panel', [] );
-		if ( ! empty( $product_types_with_panel ) )	{
+		if ( ! empty( $product_types_with_panel ) ) {
 			foreach ( $product_types_with_panel as $product_type ) {
 				$classes[] = 'show_if_' . $product_type;
 			}
@@ -251,8 +251,8 @@ class WPCV_Woo_Civi_Settings_Products {
 	 *
 	 * @since 2.4
 	 *
-	 * @param string $column_name The column name.
-	 * @param int $post_id The WordPress Post ID.
+	 * @param string  $column_name The column name.
+	 * @param integer $post_id The WordPress Post ID.
 	 */
 	public function columns_content( $column_name, $post_id ) {
 
@@ -280,8 +280,8 @@ class WPCV_Woo_Civi_Settings_Products {
 		 *
 		 * @since 3.0
 		 *
-		 * @param int Numeric 0 because we are querying the Entity.
-		 * @param int $post_id The WordPress Post ID.
+		 * @param integer Numeric 0 because we are querying the Entity.
+		 * @param integer $post_id The WordPress Post ID.
 		 * @param object $product The WooCommerce Product object.
 		 */
 		$entity_type = apply_filters( 'wpcv_woo_civi/product/query/entity_type', '', $post_id, $product );
@@ -291,8 +291,8 @@ class WPCV_Woo_Civi_Settings_Products {
 		 *
 		 * @since 3.0
 		 *
-		 * @param int Numeric 0 because we are querying the Financial Type ID.
-		 * @param int $post_id The WordPress Post ID.
+		 * @param integer Numeric 0 because we are querying the Financial Type ID.
+		 * @param integer $post_id The WordPress Post ID.
 		 * @param object $product The WooCommerce Product object.
 		 */
 		$financial_type_id = apply_filters( 'wpcv_woo_civi/product/query/financial_type_id', 0, $post_id, $product );
@@ -302,8 +302,8 @@ class WPCV_Woo_Civi_Settings_Products {
 		 *
 		 * @since 3.0
 		 *
-		 * @param int Numeric 0 because we are querying the Price Field Value ID.
-		 * @param int $post_id The WordPress Post ID.
+		 * @param integer Numeric 0 because we are querying the Price Field Value ID.
+		 * @param integer $post_id The WordPress Post ID.
 		 * @param object $product The WooCommerce Product object.
 		 */
 		$pfv_id = apply_filters( 'wpcv_woo_civi/product/query/pfv_id', 0, $post_id, $product );
@@ -321,25 +321,25 @@ class WPCV_Woo_Civi_Settings_Products {
 		// Show if this Product needs its Entity Type set.
 		if ( empty( $entity_type ) ) {
 			$feedback['entity_type'] = esc_html__( 'Excluded', 'wpcv-woo-civi-integration' );
-		// Show if this Product should not be synced to CiviCRM.
 		} elseif ( $entity_type === 'civicrm_exclude' ) {
+			// Show if this Product should not be synced to CiviCRM.
 			$feedback['entity_type'] = esc_html__( 'Excluded', 'wpcv-woo-civi-integration' );
-		// If there's a specific Entity Type for this Product, use it.
 		} elseif ( array_key_exists( $entity_type, $entity_types ) ) {
+			// If there's a specific Entity Type for this Product, use it.
 			$feedback['entity_type'] = esc_html( $entity_types[ $entity_type ] );
-		// Fall back to "Not found".
 		} else {
+			// Fall back to "Not found".
 			$feedback['entity_type'] = esc_html__( 'Entity Type not found', 'wpcv-woo-civi-integration' );
 		}
 
 		// Show if it has the legacy excluded setting.
 		if ( ! empty( $financial_type_id ) && $financial_type_id === 'exclude' ) {
 			$feedback['financial_type'] = esc_html__( 'Excluded (legacy)', 'wpcv-woo-civi-integration' );
-		// If there's a specific Financial Type for this Product, use it.
 		} elseif ( $financial_type_id !== 0 && array_key_exists( $financial_type_id, $financial_types ) ) {
+			// If there's a specific Financial Type for this Product, use it.
 			$feedback['financial_type'] = esc_html( $financial_types[ $financial_type_id ] );
-		// Fall back to "Not found".
 		} else {
+			// Fall back to "Not found".
 			$feedback['financial_type'] = esc_html__( 'Financial Type not found', 'wpcv-woo-civi-integration' );
 		}
 
@@ -366,12 +366,12 @@ class WPCV_Woo_Civi_Settings_Products {
 	 *
 	 * @since 3.0
 	 *
-	 * @param int $post_id The WordPress Post ID.
-	 * @param string $product_type The WooCommerce Product Type.
-	 * @param string $entity_type The CiviCRM Entity Type.
-	 * @param int $financial_type_id The CiviCRM Financial Type ID.
-	 * @param int $pfv_id The CiviCRM Price Field Value ID.
-	 * @return str $markup The CiviCRM Product data markup.
+	 * @param integer $post_id The WordPress Post ID.
+	 * @param string  $product_type The WooCommerce Product Type.
+	 * @param string  $entity_type The CiviCRM Entity Type.
+	 * @param integer $financial_type_id The CiviCRM Financial Type ID.
+	 * @param integer $pfv_id The CiviCRM Price Field Value ID.
+	 * @return string $markup The CiviCRM Product data markup.
 	 */
 	public function columns_data( $post_id, $product_type, $entity_type, $financial_type_id, $pfv_id ) {
 
@@ -552,7 +552,7 @@ class WPCV_Woo_Civi_Settings_Products {
 			 * @since 3.0
 			 *
 			 * @param object $product The WooCommerce Product object being saved.
-			 * @param int $financial_type_id The CiviCRM Financial Type ID.
+			 * @param integer $financial_type_id The CiviCRM Financial Type ID.
 			 */
 			do_action( 'wpcv_woo_civi/product/save/financial_type_id', $product, $financial_type_id );
 

--- a/includes/classes/class-woo-civi-settings-states.php
+++ b/includes/classes/class-woo-civi-settings-states.php
@@ -198,7 +198,7 @@ class WPCV_Woo_Civi_Settings_States {
 	 *
 	 * @since 2.0
 	 *
-	 * @param int $country_id The numeric ID of the CiviCRM Country.
+	 * @param integer $country_id The numeric ID of the CiviCRM Country.
 	 * @return str|bool $iso_code The CiviCRM Country ISO Code, or false on failure.
 	 */
 	public function get_civicrm_country_iso_code( $country_id ) {
@@ -287,8 +287,8 @@ class WPCV_Woo_Civi_Settings_States {
 	 *
 	 * @since 2.0
 	 *
-	 * @param string $woo_state The WooCommerce State.
-	 * @param int $country_id The numeric ID of the CiviCRM Country.
+	 * @param string  $woo_state The WooCommerce State.
+	 * @param integer $country_id The numeric ID of the CiviCRM Country.
 	 * @return int|bool $id The numeric ID of the CiviCRM State/Province, or false on failure.
 	 */
 	public function get_civicrm_state_province_id( $woo_state, $country_id ) {
@@ -321,7 +321,7 @@ class WPCV_Woo_Civi_Settings_States {
 	 *
 	 * @since 2.0
 	 *
-	 * @param int $state_province_id The numeric ID of the CiviCRM State.
+	 * @param integer $state_province_id The numeric ID of the CiviCRM State.
 	 * @return string|bool $name The CiviCRM State/Province Name or Abbreviation, or false on failure.
 	 */
 	public function get_civicrm_state_province_name( $state_province_id ) {

--- a/includes/classes/class-woo-civi-settings-states.php
+++ b/includes/classes/class-woo-civi-settings-states.php
@@ -151,7 +151,7 @@ class WPCV_Woo_Civi_Settings_States {
 	 * @since 2.0
 	 *
 	 * @param string $woo_country The WooCommerce Country ISO code.
-	 * @return int|bool $id The CiviCRM Country ID, or false on failure.
+	 * @return integer|bool $id The CiviCRM Country ID, or false on failure.
 	 */
 	public function get_civicrm_country_id( $woo_country ) {
 
@@ -199,7 +199,7 @@ class WPCV_Woo_Civi_Settings_States {
 	 * @since 2.0
 	 *
 	 * @param integer $country_id The numeric ID of the CiviCRM Country.
-	 * @return str|bool $iso_code The CiviCRM Country ISO Code, or false on failure.
+	 * @return string|bool $iso_code The CiviCRM Country ISO Code, or false on failure.
 	 */
 	public function get_civicrm_country_iso_code( $country_id ) {
 
@@ -289,7 +289,7 @@ class WPCV_Woo_Civi_Settings_States {
 	 *
 	 * @param string  $woo_state The WooCommerce State.
 	 * @param integer $country_id The numeric ID of the CiviCRM Country.
-	 * @return int|bool $id The numeric ID of the CiviCRM State/Province, or false on failure.
+	 * @return integer|bool $id The numeric ID of the CiviCRM State/Province, or false on failure.
 	 */
 	public function get_civicrm_state_province_id( $woo_state, $country_id ) {
 

--- a/includes/classes/class-woo-civi-settings.php
+++ b/includes/classes/class-woo-civi-settings.php
@@ -78,7 +78,7 @@ class WPCV_Woo_Civi_Settings {
 		$this->upgrade_tasks();
 
 		// Store version for later reference if there has been a change.
-		if ( $this->plugin_version != WPCV_WOO_CIVI_VERSION ) {
+		if ( $this->plugin_version !== WPCV_WOO_CIVI_VERSION ) {
 			$this->option_set( 'wpcv_woo_civi_version', WPCV_WOO_CIVI_VERSION );
 		}
 
@@ -192,7 +192,7 @@ class WPCV_Woo_Civi_Settings {
 		 *
 		 * @param array $fields The plugin fields array.
 		 */
-		return apply_filters( 'wpcv_woo_civi/woo_settings/fields', $fields );
+		$fields = apply_filters( 'wpcv_woo_civi/woo_settings/fields', $fields );
 
 		return $fields;
 
@@ -650,7 +650,7 @@ class WPCV_Woo_Civi_Settings {
 	 * @return bool $exists Whether or not the option exists.
 	 */
 	public function option_exists( $option_name = '' ) {
-		if ( $this->option_get( $option_name, 'fenfgehgefdfdjgrkj' ) == 'fenfgehgefdfdjgrkj' ) {
+		if ( $this->option_get( $option_name, 'fenfgehgefdfdjgrkj' ) === 'fenfgehgefdfdjgrkj' ) {
 			return false;
 		}
 		return true;
@@ -676,7 +676,7 @@ class WPCV_Woo_Civi_Settings {
 	 * @since 3.0
 	 *
 	 * @param string $option_name The name of the option.
-	 * @param mixed $value The value to set the option to.
+	 * @param mixed  $value The value to set the option to.
 	 * @return bool $success True if the value of the option was successfully updated.
 	 */
 	public function option_set( $option_name = '', $value = '' ) {
@@ -700,9 +700,9 @@ class WPCV_Woo_Civi_Settings {
 	 *
 	 * @since 3.0
 	 *
-	 * @param mixed $default The default value to return if the option does not exist.
+	 * @param mixed  $default The default value to return if the option does not exist.
 	 * @param string $option The option name.
-	 * @param bool $passed_default Was `get_option()` passed a default value?
+	 * @param bool   $passed_default True if `get_option()` was passed a default value.
 	 * @return mixed $default The default value when the option does not exist.
 	 */
 	public function option_panel_default( $default, $option, $passed_default ) {
@@ -721,9 +721,9 @@ class WPCV_Woo_Civi_Settings {
 	 *
 	 * @since 3.0
 	 *
-	 * @param mixed $default The default value to return if the option does not exist.
+	 * @param mixed  $default The default value to return if the option does not exist.
 	 * @param string $option The option name.
-	 * @param bool $passed_default Was `get_option()` passed a default value?
+	 * @param bool   $passed_default True if `get_option()` was passed a default value.
 	 * @return mixed $default The default value when the option does not exist.
 	 */
 	public function option_contact_type_default( $default, $option, $passed_default ) {

--- a/includes/classes/class-woo-civi-source.php
+++ b/includes/classes/class-woo-civi-source.php
@@ -23,7 +23,7 @@ class WPCV_Woo_Civi_Source {
 	 *
 	 * @since 3.0
 	 * @access public
-	 * @var str $meta_key The WooCommerce Order meta key.
+	 * @var string $meta_key The WooCommerce Order meta key.
 	 */
 	public $meta_key = '_order_source';
 
@@ -86,7 +86,7 @@ class WPCV_Woo_Civi_Source {
 	 *
 	 * @since 3.0
 	 *
-	 * @param int $order_id The Order ID.
+	 * @param integer $order_id The Order ID.
 	 * @return str|bool $source The Source string, false otherwise.
 	 */
 	public function get_order_meta( $order_id ) {
@@ -99,8 +99,8 @@ class WPCV_Woo_Civi_Source {
 	 *
 	 * @since 3.0
 	 *
-	 * @param int $order_id The Order ID.
-	 * @param str $source The Source string.
+	 * @param integer $order_id The Order ID.
+	 * @param string  $source The Source string.
 	 */
 	public function set_order_meta( $order_id, $source ) {
 		update_post_meta( $order_id, $this->meta_key, (string) $source );
@@ -111,8 +111,8 @@ class WPCV_Woo_Civi_Source {
 	 *
 	 * @since 3.0
 	 *
-	 * @param int $order_id The Order ID.
-	 * @param object $order The Order object.
+	 * @param integer $order_id The Order ID.
+	 * @param object  $order The Order object.
 	 */
 	public function order_new( $order_id, $order ) {
 
@@ -146,8 +146,8 @@ class WPCV_Woo_Civi_Source {
 	 *
 	 * @since 3.0
 	 *
-	 * @param int $order_id The Order ID.
-	 * @param object $order The Order object.
+	 * @param integer $order_id The Order ID.
+	 * @param object  $order The Order object.
 	 */
 	public function order_updated( $order_id, $order ) {
 
@@ -157,7 +157,7 @@ class WPCV_Woo_Civi_Source {
 
 		// This only needs to be done once.
 		static $done;
-		if ( isset( $done ) AND $done === true ) {
+		if ( isset( $done ) && $done === true ) {
 			return;
 		}
 
@@ -174,8 +174,8 @@ class WPCV_Woo_Civi_Source {
 	 *
 	 * @since 3.0
 	 *
-	 * @param int $order_id The Order ID.
-	 * @param object $order The Order object.
+	 * @param integer $order_id The Order ID.
+	 * @param object  $order The Order object.
 	 */
 	public function order_processed( $order_id, $order ) {
 
@@ -196,8 +196,8 @@ class WPCV_Woo_Civi_Source {
 	 *
 	 * @since 2.0
 	 *
-	 * @param int $order_id The Order ID.
-	 * @param string $new_source The new Source.
+	 * @param integer $order_id The Order ID.
+	 * @param string  $new_source The new Source.
 	 * @return bool True if successful, or false on failure.
 	 */
 	public function source_update( $order_id, $new_source ) {
@@ -261,7 +261,7 @@ class WPCV_Woo_Civi_Source {
 		 *
 		 * @since 3.0
 		 *
-		 * @param str $source The Contribution Source string.
+		 * @param string $source The Contribution Source string.
 		 * @param object $order The Order object.
 		 */
 		$source = apply_filters( 'wpcv_woo_civi/order/source/generate', $source, $order );
@@ -275,7 +275,7 @@ class WPCV_Woo_Civi_Source {
 	 *
 	 * @since 3.0
 	 *
-	 * @param array $params The existing array of params for the CiviCRM API.
+	 * @param array  $params The existing array of params for the CiviCRM API.
 	 * @param object $order The Order object.
 	 * @return array $params The modified array of params for the CiviCRM API.
 	 */
@@ -321,8 +321,8 @@ class WPCV_Woo_Civi_Source {
 	 *
 	 * @since 2.0
 	 *
-	 * @param string $column_name The column name.
-	 * @param int $post_id The WordPress Post ID.
+	 * @param string  $column_name The column name.
+	 * @param integer $post_id The WordPress Post ID.
 	 */
 	public function columns_content( $column_name, $post_id ) {
 

--- a/includes/classes/class-woo-civi-source.php
+++ b/includes/classes/class-woo-civi-source.php
@@ -87,7 +87,7 @@ class WPCV_Woo_Civi_Source {
 	 * @since 3.0
 	 *
 	 * @param integer $order_id The Order ID.
-	 * @return str|bool $source The Source string, false otherwise.
+	 * @return string|bool $source The Source string, false otherwise.
 	 */
 	public function get_order_meta( $order_id ) {
 		$source = (string) get_post_meta( $order_id, $this->meta_key, true );

--- a/includes/classes/class-woo-civi-tax.php
+++ b/includes/classes/class-woo-civi-tax.php
@@ -61,7 +61,7 @@ class WPCV_Woo_Civi_Tax {
 	public function register_hooks() {
 
 		// Modify params when an Order has a tax value.
-		add_action( 'wpcv_woo_civi/contribution/create_from_order/params', [ $this, 'contribution_tax_add' ], 100, 2 );
+		//add_action( 'wpcv_woo_civi/contribution/create_from_order/params', [ $this, 'contribution_tax_add' ], 100, 2 );
 
 		// Add Tax to Line Item.
 		add_filter( 'wpcv_woo_civi/products/line_item', [ $this, 'line_item_tax_add' ], 10, 5 );
@@ -101,7 +101,7 @@ class WPCV_Woo_Civi_Tax {
 	 *
 	 * @since 3.0
 	 *
-	 * @param array $params The existing array of params for the CiviCRM API.
+	 * @param array  $params The existing array of params for the CiviCRM API.
 	 * @param object $order The Order object.
 	 * @return array $params The modified array of params for the CiviCRM API.
 	 */
@@ -115,7 +115,6 @@ class WPCV_Woo_Civi_Tax {
 
 		// Tax is recalculated by the Order API.
 		// TODO: Review when float issues are resolved.
-		return $params;
 
 		// Assign Tax to CiviCRM API params.
 		$params['tax_amount'] = $total_tax;
@@ -148,37 +147,6 @@ class WPCV_Woo_Civi_Tax {
 		 */
 		return $params;
 
-		/*
-		// Get the default Tax/VAT Financial Type.
-		$default_financial_type_vat_id = get_option( 'woocommerce_civicrm_financial_type_vat_id' );
-
-		// Needs to be defined in Settings.
-		if ( empty( $default_financial_type_vat_id ) ) {
-
-			// Write message to CiviCRM log.
-			$message = __( 'There must be a default Tax/VAT Financial Type set.', 'wpcv-woo-civi-integration' );
-			CRM_Core_Error::debug_log_message( $message );
-
-			// Write details to PHP log.
-			$e = new \Exception();
-			$trace = $e->getTraceAsString();
-			error_log( print_r( [
-				'method' => __METHOD__,
-				'message' =>  $message,
-				'params' => $params,
-				'backtrace' => $trace,
-			], true ) );
-
-			return $params;
-
-		}
-
-		// Override with the default VAT Financial Type.
-		$params['financial_type_id'] = $default_financial_type_vat_id;
-
-		return $params;
-		*/
-
 	}
 
 	/**
@@ -186,11 +154,12 @@ class WPCV_Woo_Civi_Tax {
 	 *
 	 * @since 3.0
 	 *
-	 * @param array $line_item The array of Line Item data.
+	 * @param array  $line_item The array of Line Item data.
 	 * @param object $item The WooCommerce Item object.
 	 * @param object $product The WooCommerce Product object.
 	 * @param object $order The WooCommerce Order object.
-	 * @param array $params The params to be passed to the CiviCRM API.
+	 * @param array  $params The params to be passed to the CiviCRM API.
+	 * @return array $line_item The modified array of Line Item data.
 	 */
 	public function line_item_tax_add( $line_item, $item, $product, $order, $params ) {
 
@@ -249,7 +218,7 @@ class WPCV_Woo_Civi_Tax {
 				'account_relationship',
 				'financial_account_id',
 				'financial_account_id.financial_account_type_id',
-				'financial_account_id.tax_rate'
+				'financial_account_id.tax_rate',
 			],
 			'financial_account_id.is_active' => 1,
 			'financial_account_id.is_tax' => 1,
@@ -279,15 +248,19 @@ class WPCV_Woo_Civi_Tax {
 		}
 
 		// Return early if there's nothing to see.
-		if ( $result['count'] == 0 ) {
+		if ( 0 === (int) $result['count'] ) {
 			return false;
 		}
 
 		// Build tax rates.
-		$tax_rates = array_reduce( $result['values'], function( $tax_rates, $financial_account ) {
-			$tax_rates[ $financial_account['entity_id'] ] = $financial_account['financial_account_id.tax_rate'];
-			return $tax_rates;
-		}, [] );
+		$tax_rates = array_reduce(
+			$result['values'],
+			function( $tax_rates, $financial_account ) {
+				$tax_rates[ $financial_account['entity_id'] ] = $financial_account['financial_account_id.tax_rate'];
+				return $tax_rates;
+			},
+			[]
+		);
 
 		return $tax_rates;
 

--- a/includes/products/class-woo-civi-product-contribution.php
+++ b/includes/products/class-woo-civi-product-contribution.php
@@ -32,7 +32,7 @@ class WC_Product_CiviCRM_Contribution extends WC_Product_Simple {
 	 *
 	 * @since 3.0
 	 *
-	 * @param WC_Product|int $product Product instance or ID.
+	 * @param WC_Product|integer $product Product instance or ID.
 	 */
 	public function __construct( $product = 0 ) {
 		parent::__construct( $product );

--- a/includes/products/class-woo-civi-product-contribution.php
+++ b/includes/products/class-woo-civi-product-contribution.php
@@ -23,7 +23,7 @@ class WC_Product_CiviCRM_Contribution extends WC_Product_Simple {
 	 *
 	 * @since 3.0
 	 * @access public
-	 * @var str $product_type The WooCommerce Product Type.
+	 * @var string $product_type The WooCommerce Product Type.
 	 */
 	public $product_type = 'civicrm_contribution';
 
@@ -43,7 +43,7 @@ class WC_Product_CiviCRM_Contribution extends WC_Product_Simple {
 	 *
 	 * @since 3.0
 	 *
-	 * @param str $product_type The internal Product Type name.
+	 * @return string $product_type The internal Product Type name.
 	 */
 	public function get_type() {
 		return $this->product_type;
@@ -58,12 +58,12 @@ class WC_Product_CiviCRM_Contribution extends WC_Product_Simple {
 	 */
 	public function set_manage_stock( $manage_stock ) {
 		$this->set_prop( 'manage_stock', false );
- 		if ( true === $manage_stock ) {
- 			$this->error(
+		if ( true === $manage_stock ) {
+			$this->error(
 				'product_' . $this->product_type . '_invalid_manage_stock',
 				__( 'CiviCRM Contributions cannot be stock managed.', 'wpcv-woo-civi-integration' )
 			);
- 		}
+		}
 	}
 
 	/**
@@ -76,7 +76,7 @@ class WC_Product_CiviCRM_Contribution extends WC_Product_Simple {
 	public function set_stock_status( $stock_status = '' ) {
 		$this->set_prop( 'stock_status', 'instock' );
 		if ( 'instock' !== $stock_status ) {
- 			$this->error(
+			$this->error(
 				'product_' . $this->product_type . '_invalid_stock_status',
 				__( 'CiviCRM Contributions cannot be stock managed.', 'wpcv-woo-civi-integration' )
 			);

--- a/includes/products/class-woo-civi-product-membership.php
+++ b/includes/products/class-woo-civi-product-membership.php
@@ -32,7 +32,7 @@ class WC_Product_CiviCRM_Membership extends WC_Product_Simple {
 	 *
 	 * @since 3.0
 	 *
-	 * @param WC_Product|int $product Product instance or ID.
+	 * @param WC_Product|integer $product Product instance or ID.
 	 */
 	public function __construct( $product = 0 ) {
 		parent::__construct( $product );

--- a/includes/products/class-woo-civi-product-membership.php
+++ b/includes/products/class-woo-civi-product-membership.php
@@ -23,7 +23,7 @@ class WC_Product_CiviCRM_Membership extends WC_Product_Simple {
 	 *
 	 * @since 3.0
 	 * @access public
-	 * @var str $product_type The WooCommerce Product Type.
+	 * @var string $product_type The WooCommerce Product Type.
 	 */
 	public $product_type = 'civicrm_membership';
 
@@ -43,7 +43,7 @@ class WC_Product_CiviCRM_Membership extends WC_Product_Simple {
 	 *
 	 * @since 3.0
 	 *
-	 * @param str $product_type The internal Product Type name.
+	 * @return string $product_type The internal Product Type name.
 	 */
 	public function get_type() {
 		return $this->product_type;
@@ -58,12 +58,12 @@ class WC_Product_CiviCRM_Membership extends WC_Product_Simple {
 	 */
 	public function set_manage_stock( $manage_stock ) {
 		$this->set_prop( 'manage_stock', false );
- 		if ( true === $manage_stock ) {
- 			$this->error(
+		if ( true === $manage_stock ) {
+			$this->error(
 				'product_' . $this->product_type . '_invalid_manage_stock',
 				__( 'CiviCRM Memberships cannot be stock managed.', 'wpcv-woo-civi-integration' )
 			);
- 		}
+		}
 	}
 
 	/**
@@ -76,7 +76,7 @@ class WC_Product_CiviCRM_Membership extends WC_Product_Simple {
 	public function set_stock_status( $stock_status = '' ) {
 		$this->set_prop( 'stock_status', 'instock' );
 		if ( 'instock' !== $stock_status ) {
- 			$this->error(
+			$this->error(
 				'product_' . $this->product_type . '_invalid_stock_status',
 				__( 'CiviCRM Memberships cannot be stock managed.', 'wpcv-woo-civi-integration' )
 			);

--- a/includes/products/class-woo-civi-product-participant.php
+++ b/includes/products/class-woo-civi-product-participant.php
@@ -32,7 +32,7 @@ class WC_Product_CiviCRM_Participant extends WC_Product_Simple {
 	 *
 	 * @since 3.0
 	 *
-	 * @param WC_Product|int $product Product instance or ID.
+	 * @param WC_Product|integer $product Product instance or ID.
 	 */
 	public function __construct( $product = 0 ) {
 		parent::__construct( $product );

--- a/includes/products/class-woo-civi-product-participant.php
+++ b/includes/products/class-woo-civi-product-participant.php
@@ -23,7 +23,7 @@ class WC_Product_CiviCRM_Participant extends WC_Product_Simple {
 	 *
 	 * @since 3.0
 	 * @access public
-	 * @var str $product_type The WooCommerce Product Type.
+	 * @var string $product_type The WooCommerce Product Type.
 	 */
 	public $product_type = 'civicrm_participant';
 
@@ -43,7 +43,7 @@ class WC_Product_CiviCRM_Participant extends WC_Product_Simple {
 	 *
 	 * @since 3.0
 	 *
-	 * @param str $product_type The internal Product Type name.
+	 * @return string $product_type The internal Product Type name.
 	 */
 	public function get_type() {
 		return $this->product_type;
@@ -58,12 +58,12 @@ class WC_Product_CiviCRM_Participant extends WC_Product_Simple {
 	 */
 	public function set_manage_stock( $manage_stock ) {
 		$this->set_prop( 'manage_stock', false );
- 		if ( true === $manage_stock ) {
- 			$this->error(
+		if ( true === $manage_stock ) {
+			$this->error(
 				'product_' . $this->product_type . '_invalid_manage_stock',
 				__( 'CiviCRM Participants cannot be stock managed.', 'wpcv-woo-civi-integration' )
 			);
- 		}
+		}
 	}
 
 	/**
@@ -76,7 +76,7 @@ class WC_Product_CiviCRM_Participant extends WC_Product_Simple {
 	public function set_stock_status( $stock_status = '' ) {
 		$this->set_prop( 'stock_status', 'instock' );
 		if ( 'instock' !== $stock_status ) {
- 			$this->error(
+			$this->error(
 				'product_' . $this->product_type . '_invalid_stock_status',
 				__( 'CiviCRM Participants cannot be stock managed.', 'wpcv-woo-civi-integration' )
 			);

--- a/languages/wpcv-woo-civi-integration.pot
+++ b/languages/wpcv-woo-civi-integration.pot
@@ -5,7 +5,7 @@ msgstr ""
 "Project-Id-Version: Integrate CiviCRM with WooCommerce 3.0\n"
 "Report-Msgid-Bugs-To: https://wordpress.org/support/plugin/wpcv-woo-civi-"
 "integration\n"
-"POT-Creation-Date: 2021-05-02 17:23:10+00:00\n"
+"POT-Creation-Date: 2021-12-06 12:46:45+00:00\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
@@ -60,6 +60,168 @@ msgstr ""
 
 #: assets/civicrm/custom_php/CRM/Contact/Page/View/Purchases.php:43
 msgid "Edit"
+msgstr ""
+
+#: assets/templates/metaboxes/metabox-admin-contribution.php:23
+#: assets/templates/metaboxes/metabox-admin-event.php:46
+#: assets/templates/metaboxes/metabox-admin-membership.php:23
+msgid "Configure the Product that you want to create."
+msgstr ""
+
+#: assets/templates/metaboxes/metabox-admin-contribution.php:33
+#: assets/templates/metaboxes/metabox-admin-event.php:56
+#: assets/templates/metaboxes/metabox-admin-membership.php:33
+msgid "Product Type"
+msgstr ""
+
+#: assets/templates/metaboxes/metabox-admin-contribution.php:38
+#: assets/templates/metaboxes/metabox-admin-event.php:61
+#: assets/templates/metaboxes/metabox-admin-membership.php:38
+msgid "Simple"
+msgstr ""
+
+#: assets/templates/metaboxes/metabox-admin-contribution.php:39
+#: includes/classes/class-woo-civi-helper.php:133
+#: includes/classes/class-woo-civi-products-custom.php:78
+msgid "CiviCRM Contribution"
+msgstr ""
+
+#: assets/templates/metaboxes/metabox-admin-contribution.php:47
+#: assets/templates/metaboxes/metabox-admin-event.php:86
+#: assets/templates/metaboxes/metabox-admin-membership.php:47
+#: assets/templates/woocommerce/admin/list-tables/views/html-product-list-bulk-edit.php:35
+#: assets/templates/woocommerce/admin/list-tables/views/html-product-list-quick-edit.php:35
+#: assets/templates/woocommerce/admin/meta-boxes/views/html-product-data-panel-civicrm.php:52
+#: assets/templates/woocommerce/admin/meta-boxes/views/html-product-data-panel-variation.php:37
+#: assets/templates/woocommerce/admin/meta-boxes/views/html-product-data-settings-contribution.php:44
+#: assets/templates/woocommerce/admin/meta-boxes/views/html-product-data-settings-membership.php:45
+#: assets/templates/woocommerce/admin/meta-boxes/views/html-product-data-settings-participant.php:63
+#: includes/classes/class-woo-civi-settings.php:249
+msgid "Financial Type"
+msgstr ""
+
+#: assets/templates/metaboxes/metabox-admin-contribution.php:58
+msgid ""
+"Choose the Financial Type that is assigned to Contribution Payments. When "
+"using a Price Field Value that is part of a Price Set, the Financial Type "
+"assigned to the Price Field Value will be used."
+msgstr ""
+
+#: assets/templates/metaboxes/metabox-admin-contribution.php:64
+#: assets/templates/metaboxes/metabox-admin-event.php:103
+#: assets/templates/metaboxes/metabox-admin-membership.php:80
+#: assets/templates/woocommerce/admin/meta-boxes/views/html-product-data-panel-civicrm.php:67
+#: assets/templates/woocommerce/admin/meta-boxes/views/html-product-data-panel-variation.php:70
+#: assets/templates/woocommerce/admin/meta-boxes/views/html-product-data-settings-contribution.php:59
+#: assets/templates/woocommerce/admin/meta-boxes/views/html-product-data-settings-membership.php:78
+#: assets/templates/woocommerce/admin/meta-boxes/views/html-product-data-settings-participant.php:110
+#: includes/classes/class-woo-civi-membership.php:603
+#: includes/classes/class-woo-civi-membership.php:728
+#: includes/classes/class-woo-civi-membership.php:777
+#: includes/classes/class-woo-civi-participant.php:935
+#: includes/classes/class-woo-civi-participant.php:1122
+#: includes/classes/class-woo-civi-participant.php:1176
+msgid "Price Field Value"
+msgstr ""
+
+#. translators: %1$s: Event Title, %2$s: Price Field Value label
+#. translators: 1: Price Set title, 2: Price Field label
+#: assets/templates/metaboxes/metabox-admin-contribution.php:72
+#: assets/templates/metaboxes/metabox-admin-event.php:111
+#: assets/templates/metaboxes/metabox-admin-membership.php:88
+#: assets/templates/woocommerce/admin/meta-boxes/views/html-product-data-panel-civicrm.php:72
+#: assets/templates/woocommerce/admin/meta-boxes/views/html-product-data-panel-variation.php:76
+#: assets/templates/woocommerce/admin/meta-boxes/views/html-product-data-settings-contribution.php:64
+#: assets/templates/woocommerce/admin/meta-boxes/views/html-product-data-settings-membership.php:83
+#: assets/templates/woocommerce/admin/meta-boxes/views/html-product-data-settings-participant.php:115
+#: includes/classes/class-woo-civi-admin.php:798
+#: includes/classes/class-woo-civi-admin.php:877
+#: includes/classes/class-woo-civi-admin.php:985
+#: includes/classes/class-woo-civi-helper.php:518
+#: includes/classes/class-woo-civi-membership.php:608
+#: includes/classes/class-woo-civi-membership.php:734
+#: includes/classes/class-woo-civi-membership.php:783
+#: includes/classes/class-woo-civi-participant.php:940
+#: includes/classes/class-woo-civi-participant.php:1128
+#: includes/classes/class-woo-civi-participant.php:1182
+msgid "%1$s (%2$s)"
+msgstr ""
+
+#: assets/templates/metaboxes/metabox-admin-contribution.php:81
+#: assets/templates/metaboxes/metabox-admin-event.php:120
+#: assets/templates/metaboxes/metabox-admin-membership.php:97
+msgid ""
+"When you select more than one Price Field Value, a Variable Product will be "
+"created instead. Only add Price Field Values from the same Price Set."
+msgstr ""
+
+#: assets/templates/metaboxes/metabox-admin-event.php:26
+msgid "Source Event"
+msgstr ""
+
+#: assets/templates/metaboxes/metabox-admin-event.php:31
+#: assets/templates/woocommerce/admin/meta-boxes/views/html-product-data-settings-participant.php:77
+#: includes/classes/class-woo-civi-participant.php:904
+#: includes/classes/class-woo-civi-participant.php:1017
+msgid "Search for a CiviCRM Event&hellip;"
+msgstr ""
+
+#: assets/templates/metaboxes/metabox-admin-event.php:32
+#: assets/templates/woocommerce/admin/meta-boxes/views/html-product-data-settings-participant.php:78
+#: includes/classes/class-woo-civi-campaign.php:241
+#: includes/classes/class-woo-civi-campaign.php:323
+#: includes/classes/class-woo-civi-participant.php:558
+#: includes/classes/class-woo-civi-participant.php:905
+#: includes/classes/class-woo-civi-participant.php:1018
+msgid "None"
+msgstr ""
+
+#: assets/templates/metaboxes/metabox-admin-event.php:38
+msgid "Choose the CiviCRM Event that you want to create the Product from."
+msgstr ""
+
+#: assets/templates/metaboxes/metabox-admin-event.php:62
+#: includes/classes/class-woo-civi-participant.php:765
+#: includes/classes/class-woo-civi-products-custom.php:80
+msgid "CiviCRM Participant"
+msgstr ""
+
+#: assets/templates/metaboxes/metabox-admin-event.php:70
+#: assets/templates/woocommerce/admin/meta-boxes/views/html-product-data-settings-participant.php:99
+#: includes/classes/class-woo-civi-participant.php:926
+#: includes/classes/class-woo-civi-participant.php:1035
+#: includes/classes/class-woo-civi-participant.php:1110
+#: includes/classes/class-woo-civi-participant.php:1164
+msgid "Participant Role"
+msgstr ""
+
+#: assets/templates/metaboxes/metabox-admin-event.php:97
+msgid ""
+"Choose the Financial Type that is assigned to Payments made by Participants. "
+"When using a Price Field Value that is part of a Price Set, the Financial "
+"Type assigned to the Price Field Value will be used."
+msgstr ""
+
+#: assets/templates/metaboxes/metabox-admin-membership.php:39
+#: includes/classes/class-woo-civi-membership.php:516
+#: includes/classes/class-woo-civi-products-custom.php:79
+msgid "CiviCRM Membership"
+msgstr ""
+
+#: assets/templates/metaboxes/metabox-admin-membership.php:58
+msgid ""
+"Choose the Financial Type that is assigned to Payments made by Members. When "
+"using a Price Field Value that is part of a Price Set, the Financial Type "
+"assigned to the Price Field Value will be used."
+msgstr ""
+
+#: assets/templates/metaboxes/metabox-admin-membership.php:64
+#: assets/templates/woocommerce/admin/meta-boxes/views/html-product-data-settings-membership.php:67
+#: includes/classes/class-woo-civi-membership.php:594
+#: includes/classes/class-woo-civi-membership.php:661
+#: includes/classes/class-woo-civi-membership.php:716
+#: includes/classes/class-woo-civi-membership.php:765
+msgid "Membership Type"
 msgstr ""
 
 #: assets/templates/metaboxes/metabox-migrate-info.php:4
@@ -144,7 +306,7 @@ msgid ""
 msgstr ""
 
 #: assets/templates/metaboxes/metabox-migrate-info.php:62
-#: wpcv-woo-civi-integration.php:400
+#: wpcv-woo-civi-integration.php:554
 msgid "Settings"
 msgstr ""
 
@@ -152,11 +314,11 @@ msgstr ""
 msgid ""
 "Luckily there is no uninstall routine in the WooCommerce CiviCRM plugin at "
 "present. This means that WooCommerce CiviCRM will not auto-delete its "
-"settings when it is deleted. This plugin can therefore use those settings "
-"unchanged and you should not notice any difference once you have deactivated "
-"WooCommerce CiviCRM. Nevertheless, you should only deactivate and delete "
-"WooCommerce CiviCRM when you are sure everything mentioned here has been "
-"attended to and you have clicked \"Submit\"."
+"settings when it is deleted and this plugin can therefore use many of those "
+"legacy settings. There are some changes and additions to the CiviCRM "
+"settings on WooCommerce Products that cannot be automated - so you should "
+"only deactivate and delete WooCommerce CiviCRM when you are sure everything "
+"mentioned here has been attended to and you have clicked \"Submit\"."
 msgstr ""
 
 #: assets/templates/metaboxes/metabox-migrate-info.php:68
@@ -169,10 +331,19 @@ msgid ""
 "with WooCommerce."
 msgstr ""
 
-#: assets/templates/metaboxes/metabox-migrate-info.php:73
+#. translators: 1: Opening anchor tag, 2: Closing anchor tag
+#: assets/templates/metaboxes/metabox-migrate-info.php:76
 msgid ""
 "You can now go to your %1$sPlugins page%2$s and deactivate the WooCommerce "
 "CiviCRM plugin."
+msgstr ""
+
+#: assets/templates/metaboxes/metabox-migrate-info.php:83
+msgid ""
+"Reminder: When you have deactivated WooCommerce CiviCRM, make sure you visit "
+"the \"CiviCRM\" Settings Tab to configure Integrate CiviCRM with "
+"WooCommerce. You will also need to review the CiviCRM settings for every "
+"active Product in your Shop to ensure they are all properly configured."
 msgstr ""
 
 #: assets/templates/metaboxes/metabox-migrate-submit.php:6
@@ -186,507 +357,875 @@ msgstr ""
 #. #-#-#-#-#  wpcv-woo-civi-integration.pot (Integrate CiviCRM with WooCommerce 3.0)  #-#-#-#-#
 #. Plugin Name of the plugin/theme
 #: assets/templates/pages/page-admin-migrate.php:14
-#: includes/class-woo-civi-admin-migrate.php:187
-#: wpcv-woo-civi-integration.php:506 wpcv-woo-civi-integration.php:546
-#: wpcv-woo-civi-integration.php:586
+#: assets/templates/pages/page-admin.php:14
+#: includes/classes/class-woo-civi-admin-migrate.php:194
+#: includes/classes/class-woo-civi-admin.php:114
+#: wpcv-woo-civi-integration.php:659 wpcv-woo-civi-integration.php:700
+#: wpcv-woo-civi-integration.php:741
 msgid "Integrate CiviCRM with WooCommerce"
 msgstr ""
 
-#: assets/templates/woocommerce/admin/meta-boxes/views/html-product-data-panel-civicrm.php:28
-#: includes/class-woo-civi-settings-tab.php:156
-msgid "Financial Type"
+#: assets/templates/pages/page-admin.php:16
+msgid "Here are some utilities for creating Products from Entities in CiviCRM."
 msgstr ""
 
-#: assets/templates/woocommerce/admin/meta-boxes/views/html-product-data-panel-civicrm.php:30
+#. translators: 1: Opening anchor tag, 2: Closing anchor tag
+#: assets/templates/pages/page-admin.php:22
+msgid ""
+"If you are looking for the WooCommerce settings for this plugin, you can "
+"%1$sfind them here%2$s."
+msgstr ""
+
+#: assets/templates/woocommerce/admin/list-tables/views/html-product-list-bulk-edit.php:21
+#: assets/templates/woocommerce/admin/list-tables/views/html-product-list-quick-edit.php:21
+msgid "CiviCRM Product data"
+msgstr ""
+
+#: assets/templates/woocommerce/admin/list-tables/views/html-product-list-bulk-edit.php:24
+#: assets/templates/woocommerce/admin/list-tables/views/html-product-list-quick-edit.php:24
+#: assets/templates/woocommerce/admin/meta-boxes/views/html-product-data-panel-civicrm.php:34
+#: assets/templates/woocommerce/admin/meta-boxes/views/html-product-data-panel-variable.php:34
+msgid "Entity Type"
+msgstr ""
+
+#: assets/templates/woocommerce/admin/meta-boxes/views/html-product-data-panel-civicrm.php:36
+msgid "The CiviCRM Entity Type for this Product."
+msgstr ""
+
+#: assets/templates/woocommerce/admin/meta-boxes/views/html-product-data-panel-civicrm.php:54
+#: assets/templates/woocommerce/admin/meta-boxes/views/html-product-data-settings-contribution.php:46
+#: assets/templates/woocommerce/admin/meta-boxes/views/html-product-data-settings-membership.php:47
+#: assets/templates/woocommerce/admin/meta-boxes/views/html-product-data-settings-participant.php:65
 msgid "The CiviCRM Financial Type for this Product."
 msgstr ""
 
-#: includes/class-woo-civi-admin-migrate.php:130
+#: assets/templates/woocommerce/admin/meta-boxes/views/html-product-data-panel-civicrm.php:69
+#: assets/templates/woocommerce/admin/meta-boxes/views/html-product-data-panel-variation.php:73
+#: assets/templates/woocommerce/admin/meta-boxes/views/html-product-data-settings-contribution.php:61
+#: assets/templates/woocommerce/admin/meta-boxes/views/html-product-data-settings-membership.php:80
+#: assets/templates/woocommerce/admin/meta-boxes/views/html-product-data-settings-participant.php:112
+#: includes/classes/class-woo-civi-helper.php:511
+#: includes/classes/class-woo-civi-membership.php:605
+#: includes/classes/class-woo-civi-participant.php:937
+msgid "Select a Price Field"
+msgstr ""
+
+#: assets/templates/woocommerce/admin/meta-boxes/views/html-product-data-panel-civicrm.php:79
+#: assets/templates/woocommerce/admin/meta-boxes/views/html-product-data-settings-contribution.php:71
+msgid "Select The Price Field for the Contribution."
+msgstr ""
+
+#: assets/templates/woocommerce/admin/meta-boxes/views/html-product-data-panel-variable.php:36
+msgid ""
+"The CiviCRM Entity Type for this Product. Other CiviCRM settings are applied "
+"in the Variations."
+msgstr ""
+
+#: assets/templates/woocommerce/admin/meta-boxes/views/html-product-data-panel-variation.php:39
+msgid "The CiviCRM Financial Type for this Variation."
+msgstr ""
+
+#: assets/templates/woocommerce/admin/meta-boxes/views/html-product-data-panel-variation.php:71
+msgid "Select The Price Field for this Variation."
+msgstr ""
+
+#: assets/templates/woocommerce/admin/meta-boxes/views/html-product-data-settings-membership.php:61
+#: includes/classes/class-woo-civi-membership.php:588
+#: includes/classes/class-woo-civi-membership.php:650
+msgid "Select a Membership Type"
+msgstr ""
+
+#: assets/templates/woocommerce/admin/meta-boxes/views/html-product-data-settings-membership.php:69
+msgid ""
+"Select the Membership Type to be created in CiviCRM. The Membership will be "
+"created (with duration, plan, etc.) based on the settings in CiviCRM."
+msgstr ""
+
+#: assets/templates/woocommerce/admin/meta-boxes/views/html-product-data-settings-membership.php:90
+#: includes/classes/class-woo-civi-membership.php:615
+msgid "Select The Price Field for the Membership."
+msgstr ""
+
+#: assets/templates/woocommerce/admin/meta-boxes/views/html-product-data-settings-participant.php:76
+#: includes/classes/class-woo-civi-participant.php:903
+#: includes/classes/class-woo-civi-participant.php:1009
+#: includes/classes/class-woo-civi-participant.php:1103
+msgid "Event"
+msgstr ""
+
+#: assets/templates/woocommerce/admin/meta-boxes/views/html-product-data-settings-participant.php:85
+#: includes/classes/class-woo-civi-participant.php:912
+msgid ""
+"Select an Event if you would like this Product to create an Event "
+"Participant in CiviCRM."
+msgstr ""
+
+#: assets/templates/woocommerce/admin/meta-boxes/views/html-product-data-settings-participant.php:92
+#: includes/classes/class-woo-civi-participant.php:919
+#: includes/classes/class-woo-civi-participant.php:1001
+msgid "Select a Participant Role"
+msgstr ""
+
+#: assets/templates/woocommerce/admin/meta-boxes/views/html-product-data-settings-participant.php:101
+#: includes/classes/class-woo-civi-participant.php:928
+#: includes/classes/class-woo-civi-participant.php:1037
+msgid "Select a Participant Role for the Event Participant."
+msgstr ""
+
+#: assets/templates/woocommerce/admin/meta-boxes/views/html-product-data-settings-participant.php:122
+msgid "Select The Price Field for the Participant."
+msgstr ""
+
+#. translators: 1: Opening strong tag, 2: Closing strong tag
+#: includes/classes/class-woo-civi-admin-migrate.php:131
 msgid "You can now deactivate %1$sWooCommerce CiviCRM%2$s."
 msgstr ""
 
-#: includes/class-woo-civi-admin-migrate.php:139
+#. translators: 1: Opening anchor tag, 2: Closing anchor tag
+#: includes/classes/class-woo-civi-admin-migrate.php:142
 msgid "Please visit the %1$sPlugins Page%2$s to deactivate it."
 msgstr ""
 
-#: includes/class-woo-civi-admin-migrate.php:144
+#. translators: 1: Message, 2: Link
+#: includes/classes/class-woo-civi-admin-migrate.php:149
 msgid "%1$s %2$s"
 msgstr ""
 
-#: includes/class-woo-civi-admin-migrate.php:152
+#. translators: 1: Opening strong tag, 2: Closing strong tag, 3: Opening anchor
+#. tag, 4: Closing anchor tag
+#: includes/classes/class-woo-civi-admin-migrate.php:158
 msgid ""
-"%1$sWooCommerce CiviCRM%2$s has become %3$sIntegrate CiviCRM with WooCommerce"
-"%4$s. Please visit the %5$sMigration Page%6$s to switch over."
+"%1$sWooCommerce CiviCRM%2$s has become %1$sIntegrate CiviCRM with WooCommerce"
+"%2$s. Please visit the %5$sMigration Page%6$s to switch over."
 msgstr ""
 
-#: includes/class-woo-civi-admin-migrate.php:188
-#: wpcv-woo-civi-integration.php:507
+#: includes/classes/class-woo-civi-admin-migrate.php:195
+#: includes/classes/class-woo-civi-admin.php:115
+#: wpcv-woo-civi-integration.php:660
 msgid "WooCommerce"
 msgstr ""
 
-#: includes/class-woo-civi-admin-migrate.php:238
+#: includes/classes/class-woo-civi-admin-migrate.php:248
 msgid "{{total_products}} Products to clean up..."
 msgstr ""
 
-#: includes/class-woo-civi-admin-migrate.php:239
+#: includes/classes/class-woo-civi-admin-migrate.php:249
 msgid "Processing Products {{from_product}} to {{to_product}}"
 msgstr ""
 
-#: includes/class-woo-civi-admin-migrate.php:240
+#: includes/classes/class-woo-civi-admin-migrate.php:250
 msgid "Processing Products {{from_product}} to {{to_product}} complete"
 msgstr ""
 
-#: includes/class-woo-civi-admin-migrate.php:241
+#: includes/classes/class-woo-civi-admin-migrate.php:251
 msgid "{{total_orders}} Orders to clean up..."
 msgstr ""
 
-#: includes/class-woo-civi-admin-migrate.php:242
+#: includes/classes/class-woo-civi-admin-migrate.php:252
 msgid "Upgrading Orders {{from_order}} to {{to_order}}"
 msgstr ""
 
-#: includes/class-woo-civi-admin-migrate.php:243
+#: includes/classes/class-woo-civi-admin-migrate.php:253
 msgid "Upgrading Orders {{from_order}} to {{to_order}} complete"
 msgstr ""
 
-#: includes/class-woo-civi-admin-migrate.php:244
+#: includes/classes/class-woo-civi-admin-migrate.php:254
 msgid "All done!"
 msgstr ""
 
-#: includes/class-woo-civi-admin-migrate.php:303
-#: includes/class-woo-civi-admin-migrate.php:308
+#: includes/classes/class-woo-civi-admin-migrate.php:313
+#: includes/classes/class-woo-civi-admin-migrate.php:318
+#: includes/classes/class-woo-civi-admin.php:254
+#: includes/classes/class-woo-civi-admin.php:259
 msgid "You do not have permission to access this page."
 msgstr ""
 
-#: includes/class-woo-civi-admin-migrate.php:391
+#: includes/classes/class-woo-civi-admin-migrate.php:400
 msgid "Migration Tasks"
 msgstr ""
 
-#: includes/class-woo-civi-admin-migrate.php:393
+#: includes/classes/class-woo-civi-admin-migrate.php:402
 msgid "Migration Complete"
 msgstr ""
 
-#: includes/class-woo-civi-admin-migrate.php:406
+#: includes/classes/class-woo-civi-admin-migrate.php:415
 msgid "Upgrade Products"
 msgstr ""
 
-#: includes/class-woo-civi-admin-migrate.php:408
-#: includes/class-woo-civi-admin-migrate.php:423
+#: includes/classes/class-woo-civi-admin-migrate.php:417
+#: includes/classes/class-woo-civi-admin-migrate.php:432
 msgid "Continue Upgrading"
 msgstr ""
 
-#: includes/class-woo-civi-admin-migrate.php:421
+#: includes/classes/class-woo-civi-admin-migrate.php:430
 msgid "Upgrade Orders"
 msgstr ""
 
-#: includes/class-woo-civi-admin-migrate.php:440
+#: includes/classes/class-woo-civi-admin-migrate.php:449
 msgid "Confirm Migration"
 msgstr ""
 
-#: includes/class-woo-civi-campaign.php:180
-#: includes/class-woo-civi-campaign.php:257
-#: includes/class-woo-civi-membership.php:338
-msgid "None"
+#: includes/classes/class-woo-civi-admin.php:175
+#: includes/classes/class-woo-civi-admin.php:453
+#: includes/classes/class-woo-civi-admin.php:480
+#: includes/classes/class-woo-civi-admin.php:510
+msgid "Create Product"
 msgstr ""
 
-#: includes/class-woo-civi-campaign.php:513
+#: includes/classes/class-woo-civi-admin.php:176
+msgid "Creating..."
+msgstr ""
+
+#: includes/classes/class-woo-civi-admin.php:181
+#: includes/classes/class-woo-civi-admin.php:182
+msgid "Dismiss this notice."
+msgstr ""
+
+#: includes/classes/class-woo-civi-admin.php:340
+#: includes/classes/class-woo-civi-products-custom.php:355
+#: includes/classes/class-woo-civi-products-variable.php:259
+msgid "Select a Financial Type"
+msgstr ""
+
+#: includes/classes/class-woo-civi-admin.php:399
+msgid "Create Product for Event"
+msgstr ""
+
+#: includes/classes/class-woo-civi-admin.php:613
+msgid "Could not create WooCommerce Product."
+msgstr ""
+
+#: includes/classes/class-woo-civi-admin.php:625
+msgid "Authentication failed."
+msgstr ""
+
+#: includes/classes/class-woo-civi-admin.php:635
+msgid "Unrecognised Event."
+msgstr ""
+
+#. translators: %1$s: Opening anchor tag, %2$s: Closing anchor tag
+#: includes/classes/class-woo-civi-admin.php:654
+msgid "WooCommerce Product successfully created. %1$sView Product%1$s"
+msgstr ""
+
+#: includes/classes/class-woo-civi-admin.php:676
+msgid "Unrecognised parameters."
+msgstr ""
+
+#: includes/classes/class-woo-civi-admin.php:683
+msgid "Unrecognised Product Type."
+msgstr ""
+
+#: includes/classes/class-woo-civi-admin.php:690
+msgid "Unrecognised Financial Type."
+msgstr ""
+
+#: includes/classes/class-woo-civi-admin.php:697
+msgid "Unrecognised Price Field Values."
+msgstr ""
+
+#: includes/classes/class-woo-civi-admin.php:704
+msgid "Unrecognised Event ID."
+msgstr ""
+
+#: includes/classes/class-woo-civi-admin.php:711
+msgid "Unrecognised Participant Role."
+msgstr ""
+
+#: includes/classes/class-woo-civi-admin.php:788
+#: includes/classes/class-woo-civi-admin.php:867
+msgid "Unrecognised Price Field Value."
+msgstr ""
+
+#: includes/classes/class-woo-civi-admin.php:923
+msgid "Unrecognised Price Field."
+msgstr ""
+
+#: includes/classes/class-woo-civi-campaign.php:541
 msgid "Default Campaign"
 msgstr ""
 
-#: includes/class-woo-civi-campaign.php:614
+#: includes/classes/class-woo-civi-campaign.php:542
+msgid "The default Campaign can be overridden on individual Orders."
+msgstr ""
+
+#: includes/classes/class-woo-civi-campaign.php:677
 msgid "Unable to fetch Campaign"
 msgstr ""
 
-#: includes/class-woo-civi-campaign.php:662
-#: includes/class-woo-civi-source.php:198
-msgid "Unable to update Contribution"
-msgstr ""
-
-#: includes/class-woo-civi-campaign.php:695
+#: includes/classes/class-woo-civi-campaign.php:740
 msgid "Campaign"
 msgstr ""
 
-#: includes/class-woo-civi-campaign.php:757
+#: includes/classes/class-woo-civi-campaign.php:809
 msgid "All campaigns"
 msgstr ""
 
-#: includes/class-woo-civi-campaign.php:854
-#: includes/class-woo-civi-campaign.php:855
+#: includes/classes/class-woo-civi-campaign.php:907
+msgid "CiviCRM Campaign:"
+msgstr ""
+
+#: includes/classes/class-woo-civi-campaign.php:908
 msgid "CiviCRM Campaign"
 msgstr ""
 
-#. translators: %1$s: Address Type, %2$s: Street Address
-#: includes/class-woo-civi-contact-address.php:172
+#. translators: 1: Address Type, 2: Street Address
+#: includes/classes/class-woo-civi-contact-address.php:172
 msgid "Created new CiviCRM Address of type %1$s: %2$s"
 msgstr ""
 
-#: includes/class-woo-civi-contact-address.php:186
+#: includes/classes/class-woo-civi-contact-address.php:186
 msgid "Unable to add/update Address"
 msgstr ""
 
-#: includes/class-woo-civi-contact-address.php:429
+#: includes/classes/class-woo-civi-contact-address.php:429
 msgid "Unable to fetch Address"
 msgstr ""
 
-#: includes/class-woo-civi-contact-address.php:461
+#: includes/classes/class-woo-civi-contact-address.php:461
 msgid "Unable to create/update Address"
 msgstr ""
 
-#. translators: %1$s: Location Type, %2$s: Email Address
-#: includes/class-woo-civi-contact-email.php:128
+#. translators: 1: Location Type, 2: Email Address
+#: includes/classes/class-woo-civi-contact-email.php:128
 msgid "Created new CiviCRM Email of type %1$s: %2$s"
 msgstr ""
 
-#: includes/class-woo-civi-contact-email.php:142
+#: includes/classes/class-woo-civi-contact-email.php:142
 msgid "Unable to add/update Email"
 msgstr ""
 
-#: includes/class-woo-civi-contact-email.php:280
+#: includes/classes/class-woo-civi-contact-email.php:280
 msgid "Unable to fetch Email"
 msgstr ""
 
-#: includes/class-woo-civi-contact-email.php:312
+#: includes/classes/class-woo-civi-contact-email.php:312
 msgid "Unable to create/update Email"
 msgstr ""
 
-#: includes/class-woo-civi-contact-orders-tab.php:210
+#: includes/classes/class-woo-civi-contact-orders-tab.php:152
 msgid "Woo Orders"
 msgstr ""
 
-#: includes/class-woo-civi-contact-orders-tab.php:242
+#: includes/classes/class-woo-civi-contact-orders-tab.php:185
 msgid "Unable to find Contact"
 msgstr ""
 
-#: includes/class-woo-civi-contact-orders-tab.php:260
+#: includes/classes/class-woo-civi-contact-orders-tab.php:203
 msgctxt "Order status"
 msgid "Pending payment"
 msgstr ""
 
-#: includes/class-woo-civi-contact-orders-tab.php:261
+#: includes/classes/class-woo-civi-contact-orders-tab.php:204
 msgctxt "Order status"
 msgid "Processing"
 msgstr ""
 
-#: includes/class-woo-civi-contact-orders-tab.php:262
+#: includes/classes/class-woo-civi-contact-orders-tab.php:205
 msgctxt "Order status"
 msgid "On hold"
 msgstr ""
 
-#: includes/class-woo-civi-contact-orders-tab.php:263
+#: includes/classes/class-woo-civi-contact-orders-tab.php:206
 msgctxt "Order status"
 msgid "Completed"
 msgstr ""
 
-#: includes/class-woo-civi-contact-orders-tab.php:264
+#: includes/classes/class-woo-civi-contact-orders-tab.php:207
 msgctxt "Order status"
 msgid "Cancelled"
 msgstr ""
 
-#: includes/class-woo-civi-contact-orders-tab.php:265
+#: includes/classes/class-woo-civi-contact-orders-tab.php:208
 msgctxt "Order status"
 msgid "Refunded"
 msgstr ""
 
-#: includes/class-woo-civi-contact-orders-tab.php:266
+#: includes/classes/class-woo-civi-contact-orders-tab.php:209
 msgctxt "Order status"
 msgid "Failed"
 msgstr ""
 
 #. translators: %1$s: Location Type, %2$s: Phone Number
-#: includes/class-woo-civi-contact-phone.php:128
+#: includes/classes/class-woo-civi-contact-phone.php:128
 msgid "Created new CiviCRM Phone of type %1$s: %2$s"
 msgstr ""
 
-#: includes/class-woo-civi-contact-phone.php:142
+#: includes/classes/class-woo-civi-contact-phone.php:142
 msgid "Unable to add/update Phone"
 msgstr ""
 
-#: includes/class-woo-civi-contact-phone.php:279
+#: includes/classes/class-woo-civi-contact-phone.php:279
 msgid "Unable to fetch Phone"
 msgstr ""
 
-#: includes/class-woo-civi-contact-phone.php:311
+#: includes/classes/class-woo-civi-contact-phone.php:311
 msgid "Unable to create/update Phone"
 msgstr ""
 
-#: includes/class-woo-civi-contact.php:255
+#: includes/classes/class-woo-civi-contact.php:257
 msgid "CiviCRM Contact could not be fetched"
 msgstr ""
 
-#: includes/class-woo-civi-contact.php:264
+#: includes/classes/class-woo-civi-contact.php:266
 msgid "CiviCRM Contact could not be created"
 msgstr ""
 
-#: includes/class-woo-civi-contact.php:272
+#: includes/classes/class-woo-civi-contact.php:274
 msgid "CiviCRM Contact could not be updated"
 msgstr ""
 
-#: includes/class-woo-civi-contact.php:322
+#: includes/classes/class-woo-civi-contact.php:324
 msgid "Failed to get Contact by ID"
 msgstr ""
 
-#: includes/class-woo-civi-contact.php:384
+#: includes/classes/class-woo-civi-contact.php:386
 msgid "Failed to get Contact by Email"
 msgstr ""
 
-#: includes/class-woo-civi-contact.php:569
+#: includes/classes/class-woo-civi-contact.php:571
 msgid "Unable to retrieve CiviCRM UFMatch data."
 msgstr ""
 
-#: includes/class-woo-civi-contact.php:682
+#: includes/classes/class-woo-civi-contact.php:683
 msgid "A numerical ID must be present to update a Contact."
 msgstr ""
 
-#: includes/class-woo-civi-contact.php:773
-#: includes/class-woo-civi-contact.php:873
+#: includes/classes/class-woo-civi-contact.php:781
+#: includes/classes/class-woo-civi-contact.php:924
 msgid "Unknown Name"
 msgstr ""
 
-#: includes/class-woo-civi-contact.php:777
-msgid "WooCommerce purchase"
+#: includes/classes/class-woo-civi-contact.php:785
+msgid "WooCommerce Purchase"
 msgstr ""
 
-#: includes/class-woo-civi-contact.php:784
+#: includes/classes/class-woo-civi-contact.php:792
 msgid "Unable to create Contact"
 msgstr ""
 
-#: includes/class-woo-civi-contact.php:881
+#: includes/classes/class-woo-civi-contact.php:932
 msgid "Unable to update Contact"
 msgstr ""
 
-#. translators: %s: The Financial Type
-#: includes/class-woo-civi-helper.php:179
-msgid "Default (%s)"
+#: includes/classes/class-woo-civi-contact.php:1040
+msgid "Individual"
 msgstr ""
 
-#: includes/class-woo-civi-helper.php:180
-#: includes/class-woo-civi-products-tab.php:160
-msgid "Not set"
+#: includes/classes/class-woo-civi-contact.php:1041
+msgid "Household"
 msgstr ""
 
-#: includes/class-woo-civi-helper.php:185
-#: includes/class-woo-civi-products-tab.php:181
-#: includes/class-woo-civi-products-tab.php:215
-msgid "Exclude"
+#: includes/classes/class-woo-civi-contact.php:1042
+msgid "Organization"
 msgstr ""
 
-#: includes/class-woo-civi-helper.php:224
-msgid "Unable to fetch Decimal Separator"
+#: includes/classes/class-woo-civi-contact.php:1133
+msgid "No Sub-type selected"
 msgstr ""
 
-#: includes/class-woo-civi-helper.php:276
-msgid "Unable to fetch Thousand Separator"
+#: includes/classes/class-woo-civi-contribution.php:151
+msgid "Error trying to find Contribution by ID"
 msgstr ""
 
-#: includes/class-woo-civi-helper.php:359
-#: includes/class-woo-civi-helper.php:420
+#: includes/classes/class-woo-civi-contribution.php:270
 msgid "Error try to find Contribution by Invoice ID"
 msgstr ""
 
-#: includes/class-woo-civi-helper.php:487
-msgid "Unable to retrieve default Price Set"
+#: includes/classes/class-woo-civi-contribution.php:366
+msgid "Error when creating/updating a Contribution"
 msgstr ""
 
-#: includes/class-woo-civi-membership.php:116
-msgid "Membership Type"
+#: includes/classes/class-woo-civi-contribution.php:412
+msgid "A numeric ID must be present to update a Contribution."
 msgstr ""
 
-#: includes/class-woo-civi-membership.php:118
+#: includes/classes/class-woo-civi-contribution.php:446
+msgid "Unable to create an Order via the CiviCRM Order API"
+msgstr ""
+
+#. translators: %d: The numeric ID of the WooCommerce Order
+#: includes/classes/class-woo-civi-contribution.php:514
+#: includes/classes/class-woo-civi-contribution.php:678
+msgid "WooCommerce Order - %d"
+msgstr ""
+
+#: includes/classes/class-woo-civi-contribution.php:733
+msgid "Unable to create Payment record."
+msgstr ""
+
+#: includes/classes/class-woo-civi-contribution.php:794
+msgid "Unable to create a Note for a Contribution."
+msgstr ""
+
+#: includes/classes/class-woo-civi-contribution.php:869
+msgid "Unable to update Contribution Status"
+msgstr ""
+
+#. translators: %s: The name of the requested CiviCRM Setting
+#: includes/classes/class-woo-civi-helper.php:94
+msgid "Unable to fetch the \"%s\" setting."
+msgstr ""
+
+#: includes/classes/class-woo-civi-helper.php:132
+msgid "Do not sync to CiviCRM"
+msgstr ""
+
+#: includes/classes/class-woo-civi-helper.php:305
+msgid "Unable to fetch Price Sets"
+msgstr ""
+
+#: includes/classes/class-woo-civi-helper.php:364
+msgid "Unable to fetch Price Field Values"
+msgstr ""
+
+#: includes/classes/class-woo-civi-helper.php:659
+msgid "Unable to fetch Decimal Separator"
+msgstr ""
+
+#: includes/classes/class-woo-civi-helper.php:717
+msgid "Unable to fetch Thousand Separator"
+msgstr ""
+
+#: includes/classes/class-woo-civi-membership.php:232
+#: includes/classes/class-woo-civi-source.php:253
+msgid "Shop"
+msgstr ""
+
+#: includes/classes/class-woo-civi-membership.php:366
+msgid "Unable to retrieve CiviCRM Membership Types."
+msgstr ""
+
+#: includes/classes/class-woo-civi-membership.php:428
+msgid "Unable to retrieve CiviCRM Membership Type."
+msgstr ""
+
+#: includes/classes/class-woo-civi-membership.php:480
+msgid "Unable to retrieve default Membership Price Field ID"
+msgstr ""
+
+#: includes/classes/class-woo-civi-membership.php:596
 msgid ""
 "Select a Membership Type if you would like this Product to create a "
 "Membership in CiviCRM. The Membership will be created (with duration, plan, "
 "etc.) based on the settings in CiviCRM."
 msgstr ""
 
-#: includes/class-woo-civi-membership.php:169
-#: includes/class-woo-civi-source.php:232
-msgid "Shop"
+#: includes/classes/class-woo-civi-membership.php:663
+msgid ""
+"Select a Membership Type if you would like this Product Variation to create "
+"a Membership in CiviCRM. The Membership will be created (with duration, "
+"plan, etc.) based on the settings in CiviCRM."
 msgstr ""
 
-#: includes/class-woo-civi-membership.php:317
-msgid "Unable to retrieve CiviCRM Membership Types."
+#: includes/classes/class-woo-civi-membership.php:708
+#: includes/classes/class-woo-civi-membership.php:731
+#: includes/classes/class-woo-civi-participant.php:1095
+#: includes/classes/class-woo-civi-participant.php:1125
+msgid "- No Change -"
 msgstr ""
 
-#: includes/class-woo-civi-membership.php:382
-msgid "Unable to retrieve CiviCRM Membership Type."
-msgstr ""
-
-#: includes/class-woo-civi-orders.php:253
-msgid "Unable to update Order Status"
-msgstr ""
-
-#. translators: %d: The numeric ID of the WooCommerce Order
-#: includes/class-woo-civi-orders.php:292
-msgid "WooCommerce Order - %d"
-msgstr ""
-
-#: includes/class-woo-civi-orders.php:342
-msgid "Unable to add Contribution"
+#: includes/classes/class-woo-civi-membership.php:757
+#: includes/classes/class-woo-civi-membership.php:780
+#: includes/classes/class-woo-civi-participant.php:1152
+#: includes/classes/class-woo-civi-participant.php:1179
+#: includes/classes/class-woo-civi-settings-products.php:580
+#: includes/classes/class-woo-civi-settings-products.php:585
+msgid "Not set"
 msgstr ""
 
 #. translators: %s: The View Contribution link
-#: includes/class-woo-civi-orders.php:382
+#: includes/classes/class-woo-civi-order.php:271
 msgid "Contribution %s has been created in CiviCRM"
 msgstr ""
 
-#: includes/class-woo-civi-orders.php:471
-msgid "There must be a default VAT Financial Type set."
-msgstr ""
-
-#: includes/class-woo-civi-orders.php:573
-#: includes/class-woo-civi-orders.php:595
+#: includes/classes/class-woo-civi-order.php:291
+#: includes/classes/class-woo-civi-order.php:313
 msgid "View"
 msgstr ""
 
 #. translators: %s: The link to the Contact in CiviCRM
-#: includes/class-woo-civi-orders.php:576
+#: includes/classes/class-woo-civi-order.php:294
 msgid "Created new CiviCRM Contact - %s"
 msgstr ""
 
 #. translators: %s: The link to the Contact in CiviCRM
-#: includes/class-woo-civi-orders.php:598
+#: includes/classes/class-woo-civi-order.php:316
 msgid "CiviCRM Contact Updated - %s"
 msgstr ""
 
-#: includes/class-woo-civi-orders.php:639
+#: includes/classes/class-woo-civi-order.php:355
+msgid "CiviCRM Contact:"
+msgstr ""
+
+#: includes/classes/class-woo-civi-order.php:355
 msgid "View Contact in CiviCRM"
 msgstr ""
 
-#: includes/class-woo-civi-products-tab.php:80
+#. translators: 1: Source text, 2: Product name
+#: includes/classes/class-woo-civi-participant.php:296
+msgid "%1$s: %2$s"
+msgstr ""
+
+#: includes/classes/class-woo-civi-participant.php:661
+msgid "Unable to retrieve CiviCRM Participant Role Option Group."
+msgstr ""
+
+#: includes/classes/class-woo-civi-participant.php:947
+msgid "Select The Price Field for the Event Participant."
+msgstr ""
+
+#: includes/classes/class-woo-civi-participant.php:1010
+msgid ""
+"Select an Event if you would like this Product Variation to create an Event "
+"Participant in CiviCRM."
+msgstr ""
+
+#: includes/classes/class-woo-civi-participant.php:1105
+#: includes/classes/class-woo-civi-participant.php:1160
+msgid "Edit the Product to set the Event"
+msgstr ""
+
+#: includes/classes/class-woo-civi-products-custom.php:283
+#: includes/classes/class-woo-civi-settings-products.php:96
 msgid "CiviCRM Settings"
 msgstr ""
 
-#. translators: %s: The default Financial Type
-#: includes/class-woo-civi-products-tab.php:163
-msgid "%s (Default)"
+#: includes/classes/class-woo-civi-products-variable.php:139
+msgid "CiviCRM Entity"
 msgstr ""
 
-#: includes/class-woo-civi-products-tab.php:177
-#: includes/class-woo-civi-products-tab.php:211
-msgid "— No change —"
+#. translators: 1: Product Name, 2: Quantity
+#: includes/classes/class-woo-civi-products.php:338
+msgid "%1$s x %2$s"
 msgstr ""
 
-#: includes/class-woo-civi-products-tab.php:186
-#: includes/class-woo-civi-products-tab.php:220
-msgid "Contribution Type"
+#: includes/classes/class-woo-civi-products.php:488
+msgid "There must be a default Shipping Financial Type set."
 msgstr ""
 
-#: includes/class-woo-civi-settings-network.php:96
-#: includes/class-woo-civi-settings-network.php:97
-#: includes/class-woo-civi-settings-network.php:119
+#: includes/classes/class-woo-civi-products.php:562
+msgid "Unable to retrieve default Contribution Price Field ID"
+msgstr ""
+
+#: includes/classes/class-woo-civi-products.php:763
+msgid "Error trying to find Line Items by Contribution ID"
+msgstr ""
+
+#: includes/classes/class-woo-civi-settings-network.php:91
+#: includes/classes/class-woo-civi-settings-network.php:92
+#: includes/classes/class-woo-civi-settings-network.php:115
 msgid "Integrate CiviCRM with WooCommerce Settings"
 msgstr ""
 
-#: includes/class-woo-civi-settings-network.php:143
+#: includes/classes/class-woo-civi-settings-network.php:140
 msgid "General settings"
 msgstr ""
 
-#: includes/class-woo-civi-settings-network.php:150
+#: includes/classes/class-woo-civi-settings-network.php:147
 msgid "Main WooCommerce Site ID"
 msgstr ""
 
-#: includes/class-woo-civi-settings-network.php:157
+#: includes/classes/class-woo-civi-settings-network.php:154
 msgid "The ID of the Site where the WooCommerce Shop is located."
 msgstr ""
 
-#: includes/class-woo-civi-settings-network.php:209
+#: includes/classes/class-woo-civi-settings-network.php:209
 msgid "Cheating uh?"
 msgstr ""
 
-#: includes/class-woo-civi-settings-tab.php:72
-#: wpcv-woo-civi-integration.php:547 wpcv-woo-civi-integration.php:587
+#: includes/classes/class-woo-civi-settings-products.php:274
+msgid "N/A"
+msgstr ""
+
+#: includes/classes/class-woo-civi-settings-products.php:323
+#: includes/classes/class-woo-civi-settings-products.php:326
+msgid "Excluded"
+msgstr ""
+
+#: includes/classes/class-woo-civi-settings-products.php:332
+msgid "Entity Type not found"
+msgstr ""
+
+#: includes/classes/class-woo-civi-settings-products.php:337
+msgid "Excluded (legacy)"
+msgstr ""
+
+#: includes/classes/class-woo-civi-settings-products.php:343
+msgid "Financial Type not found"
+msgstr ""
+
+#: includes/classes/class-woo-civi-settings-products.php:480
+#: includes/classes/class-woo-civi-settings-products.php:485
+msgid "— No Change —"
+msgstr ""
+
+#: includes/classes/class-woo-civi-settings.php:149
+#: wpcv-woo-civi-integration.php:701 wpcv-woo-civi-integration.php:742
 msgid "CiviCRM"
 msgstr ""
 
-#: includes/class-woo-civi-settings-tab.php:135
-msgid "Contribution settings"
+#: includes/classes/class-woo-civi-settings.php:213
+msgid "Order settings"
 msgstr ""
 
-#: includes/class-woo-civi-settings-tab.php:137
+#: includes/classes/class-woo-civi-settings.php:215
 msgid ""
-"Below are the default settings that  are used when creating Contributions in "
-"CiviCRM. These settings can be overridden on individual Products on the "
-"\"CiviCRM Settings\" tab."
+"This plugin needs to know some information to configure the Orders that are "
+"created in CiviCRM."
 msgstr ""
 
-#: includes/class-woo-civi-settings-tab.php:162
-msgid "Tax/VAT Financial Type"
+#: includes/classes/class-woo-civi-settings.php:234
+msgid "Pay Later Payment Methods"
 msgstr ""
 
-#: includes/class-woo-civi-settings-tab.php:168
-msgid "Shipping Financial Type"
+#: includes/classes/class-woo-civi-settings.php:239
+msgid ""
+"Select all the WooCommerce Payment Methods that are considered \"Pay Later\" "
+"in CiviCRM."
 msgstr ""
 
-#: includes/class-woo-civi-settings-tab.php:174
+#: includes/classes/class-woo-civi-settings.php:243
 msgid "Do not create 0 amount Contributions"
 msgstr ""
 
-#: includes/class-woo-civi-settings-tab.php:176
+#: includes/classes/class-woo-civi-settings.php:245
 msgid ""
-"Do not create Contributions for Orders with a total of 0, i.e. free Products "
-"or using a Coupon."
+"Do not create Contributions for Orders with a total of 0, e.g. for free "
+"Products or when using a Coupon."
 msgstr ""
 
-#: includes/class-woo-civi-settings-tab.php:226
+#: includes/classes/class-woo-civi-settings.php:251
+msgid ""
+"CiviCRM needs to know what Financial Type to assign to an Order when there "
+"are multiple Products in that Order. (Note: every Product that creates a "
+"Contribution in CiviCRM should have its Entity Type, Financial Type and "
+"Price Field specified in its \"CiviCRM Settings\" tab.)"
+msgstr ""
+
+#: includes/classes/class-woo-civi-settings.php:256
+msgid "Shipping Financial Type"
+msgstr ""
+
+#: includes/classes/class-woo-civi-settings.php:312
+msgid "Product settings"
+msgstr ""
+
+#: includes/classes/class-woo-civi-settings.php:322
+msgid "Product Types with CiviCRM Settings"
+msgstr ""
+
+#: includes/classes/class-woo-civi-settings.php:327
+msgid ""
+"Select the WooCommerce Product Types to show the CiviCRM Settings panel on. "
+"You will need to update this setting if you enable additional plugins that "
+"provide Custom Product Types that you want to include as Line Items in "
+"CiviCRM Orders."
+msgstr ""
+
+#: includes/classes/class-woo-civi-settings.php:388
+msgid "Contact settings"
+msgstr ""
+
+#: includes/classes/class-woo-civi-settings.php:398
+msgid "Contact Type"
+msgstr ""
+
+#: includes/classes/class-woo-civi-settings.php:400
+msgid ""
+"Select the type of Contact that is created when an Order is processed. The "
+"most common (and recommended) configuration is to have this set to "
+"\"Individual\". Stick with the default unless you have a good reason to "
+"change it."
+msgstr ""
+
+#: includes/classes/class-woo-civi-settings.php:405
+msgid "Contact Sub-type"
+msgstr ""
+
+#. translators: %1$s: Opening anchor tag, %2$s: Closing anchor tag
+#: includes/classes/class-woo-civi-settings.php:408
+msgid ""
+"Select the sub-type that is assigned to Contacts created (or updated) when "
+"an Order is processed. Leave this set to \"No Sub-type selected\" if you do "
+"not want new Contacts to have a sub-type. Tip: you can manage your "
+"%1$sContact Sub-types in CiviCRM%2$s."
+msgstr ""
+
+#: includes/classes/class-woo-civi-settings.php:413
+msgid "Dedupe Rule"
+msgstr ""
+
+#: includes/classes/class-woo-civi-settings.php:415
+msgid "Select the Dedupe Rule to use when matching Users to Contacts."
+msgstr ""
+
+#: includes/classes/class-woo-civi-settings.php:477
 msgid "Address, Phone and Email settings"
 msgstr ""
 
-#: includes/class-woo-civi-settings-tab.php:248
+#: includes/classes/class-woo-civi-settings.php:499
 msgid "Billing Location Type"
 msgstr ""
 
-#: includes/class-woo-civi-settings-tab.php:254
+#: includes/classes/class-woo-civi-settings.php:505
 msgid "Shipping Location Type"
 msgstr ""
 
-#: includes/class-woo-civi-settings-tab.php:260
+#. translators: %1$s: Opening anchor tag, %2$s: Closing anchor tag
+#: includes/classes/class-woo-civi-settings.php:508
+msgid "Tip: you can manage your %1$sLocation Types in CiviCRM%2$s."
+msgstr ""
+
+#: includes/classes/class-woo-civi-settings.php:513
 msgid "Sync Address"
 msgstr ""
 
-#: includes/class-woo-civi-settings-tab.php:262
+#: includes/classes/class-woo-civi-settings.php:515
 msgid ""
 "Synchronize WooCommerce User Address with its matching CiviCRM Contact "
 "Address and vice versa."
 msgstr ""
 
-#: includes/class-woo-civi-settings-tab.php:266
+#: includes/classes/class-woo-civi-settings.php:519
 msgid "Sync Billing Phone"
 msgstr ""
 
-#: includes/class-woo-civi-settings-tab.php:268
+#: includes/classes/class-woo-civi-settings.php:521
 msgid ""
 "Synchronize WooCommerce User Billing Phone Number with its matching CiviCRM "
 "Contact Billing Phone Number and vice versa."
 msgstr ""
 
-#: includes/class-woo-civi-settings-tab.php:272
+#: includes/classes/class-woo-civi-settings.php:525
 msgid "Sync Billing Email"
 msgstr ""
 
-#: includes/class-woo-civi-settings-tab.php:274
+#: includes/classes/class-woo-civi-settings.php:527
 msgid ""
 "Synchronize WooCommerce User Billing Email with its matching CiviCRM Contact "
 "Billing Email and vice versa."
 msgstr ""
 
-#: includes/class-woo-civi-settings-tab.php:324
+#: includes/classes/class-woo-civi-settings.php:577
 msgid "Other settings"
 msgstr ""
 
-#: includes/class-woo-civi-settings-tab.php:345
+#: includes/classes/class-woo-civi-settings.php:598
 msgid "Hide \"Woo Orders\" Tab for non-customers"
 msgstr ""
 
-#: includes/class-woo-civi-settings-tab.php:347
+#: includes/classes/class-woo-civi-settings.php:600
 msgid ""
 "Remove the \"Woo Orders\" Tab from the CiviCRM Contact screen for non-"
 "customer Contacts."
 msgstr ""
 
-#: includes/class-woo-civi-settings-tab.php:351
+#: includes/classes/class-woo-civi-settings.php:604
 msgid "Replace WooCommerce States"
 msgstr ""
 
-#: includes/class-woo-civi-settings-tab.php:353
+#: includes/classes/class-woo-civi-settings.php:606
 msgid ""
 "WARNING, POSSIBLE DATA LOSS! If enabled, this plugin will replace the list "
 "of States/Countries in WooCommerce with the States/Provinces list from "
@@ -695,47 +1234,77 @@ msgid ""
 "WooCommerce Settings that rely on State/Country will have to be reconfigured."
 msgstr ""
 
-#: includes/class-woo-civi-source.php:277
+#: includes/classes/class-woo-civi-source.php:309
 msgid "Source"
 msgstr ""
 
-#: includes/class-woo-civi-source.php:328
+#: includes/classes/class-woo-civi-source.php:360
 msgid "All sources"
 msgstr ""
 
-#: includes/class-woo-civi-source.php:401
-#: includes/class-woo-civi-source.php:402
+#: includes/classes/class-woo-civi-source.php:434
+msgid "CiviCRM Source:"
+msgstr ""
+
+#: includes/classes/class-woo-civi-source.php:435
 msgid "CiviCRM Source"
 msgstr ""
 
-#: wpcv-woo-civi-integration.php:504 wpcv-woo-civi-integration.php:544
-#: wpcv-woo-civi-integration.php:584
+#: includes/products/class-woo-civi-product-contribution.php:64
+#: includes/products/class-woo-civi-product-contribution.php:81
+msgid "CiviCRM Contributions cannot be stock managed."
+msgstr ""
+
+#: includes/products/class-woo-civi-product-contribution.php:98
+msgid "CiviCRM Contributions cannot be backordered."
+msgstr ""
+
+#: includes/products/class-woo-civi-product-membership.php:64
+#: includes/products/class-woo-civi-product-membership.php:81
+msgid "CiviCRM Memberships cannot be stock managed."
+msgstr ""
+
+#: includes/products/class-woo-civi-product-membership.php:98
+msgid "CiviCRM Memberships cannot be backordered."
+msgstr ""
+
+#: includes/products/class-woo-civi-product-participant.php:64
+#: includes/products/class-woo-civi-product-participant.php:81
+msgid "CiviCRM Participants cannot be stock managed."
+msgstr ""
+
+#: includes/products/class-woo-civi-product-participant.php:98
+msgid "CiviCRM Participants cannot be backordered."
+msgstr ""
+
+#: wpcv-woo-civi-integration.php:657 wpcv-woo-civi-integration.php:698
+#: wpcv-woo-civi-integration.php:739
 msgid "Activation failed"
 msgstr ""
 
 #. translators: %1$s: The plugin name, %2$s: WooCommerce
-#: wpcv-woo-civi-integration.php:511 wpcv-woo-civi-integration.php:551
+#: wpcv-woo-civi-integration.php:664 wpcv-woo-civi-integration.php:705
 msgid "%1$s requires %2$s to be installed and activated."
 msgstr ""
 
 #. translators: %s: WooCommerce
-#: wpcv-woo-civi-integration.php:517 wpcv-woo-civi-integration.php:557
+#: wpcv-woo-civi-integration.php:670 wpcv-woo-civi-integration.php:711
 msgid "This plugin has been deactivated! Please activate %s and try again."
 msgstr ""
 
 #. translators: %1$s: The opening anchor tag, %2$s: The closing anchor tag
-#: wpcv-woo-civi-integration.php:522 wpcv-woo-civi-integration.php:562
-#: wpcv-woo-civi-integration.php:602
+#: wpcv-woo-civi-integration.php:675 wpcv-woo-civi-integration.php:716
+#: wpcv-woo-civi-integration.php:757
 msgid "Back to the WordPress %1$splugins page%2$s."
 msgstr ""
 
 #. translators: %1$s: The plugin name, %2$s: WooCommerce
-#: wpcv-woo-civi-integration.php:591
+#: wpcv-woo-civi-integration.php:746
 msgid "%1$s requires %2$s to be fully installed and configured."
 msgstr ""
 
 #. translators: %s: WooCommerce
-#: wpcv-woo-civi-integration.php:597
+#: wpcv-woo-civi-integration.php:752
 msgid "This plugin has been deactivated! Please configure %s and try again."
 msgstr ""
 
@@ -744,13 +1313,13 @@ msgid "https://github.com/WPCV/wpcv-woo-civi-integration"
 msgstr ""
 
 #. Description of the plugin/theme
-msgid "Provides integration between CiviCRM with WooCommerce."
+msgid "Provides integration between CiviCRM and WooCommerce."
 msgstr ""
 
 #. Author of the plugin/theme
-msgid "Andrei Mondoc"
+msgid "WPCV"
 msgstr ""
 
 #. Author URI of the plugin/theme
-msgid "https://github.com/mecachisenros"
+msgid "https://github.com/WPCV"
 msgstr ""

--- a/phpcs.xml
+++ b/phpcs.xml
@@ -1,0 +1,59 @@
+<?xml version="1.0"?>
+<ruleset name="CMW.WordPress">
+
+	<!-- Add source codes in the report -->
+	<arg value="s"/>
+	<arg name="colors"/>
+
+	<!-- Check all PHP files in directory tree by default. -->
+	<arg name="extensions" value="php"/>
+	<file>.</file>
+
+	<rule ref="WordPress">
+
+		<!-- I prefer slash-delimited Hooks -->
+		<exclude name="WordPress.NamingConventions.ValidHookName.UseUnderscores" />
+
+		<!-- Yoda? Really? -->
+		<exclude name="WordPress.PHP.YodaConditions.NotYoda" />
+
+		<!-- I prefer my control structures -->
+		<exclude name="WordPress.WhiteSpace.ControlStructureSpacing.BlankLineAfterEnd" />
+
+		<!-- Not a fan of arrow or equals alignment -->
+		<exclude name="WordPress.Arrays.MultipleStatementAlignment.DoubleArrowNotAligned" />
+		<exclude name="Generic.Formatting.MultipleStatementAlignment.NotSameWarning" />
+
+		<!-- PSR4 -->
+		<exclude name="WordPress.Files.FileName.InvalidClassFileName"/>
+		<exclude name="WordPress.Files.FileName.NotHyphenatedLowercase"/>
+
+	</rule>
+
+	<rule ref="WordPress.WP.I18n">
+		<properties>
+			<property name="text_domain" type="array" value="wpcv-woo-civi-integration" />
+		</properties>
+	</rule>
+
+	<!-- Allow short array syntax -->
+	<rule ref="Generic.Arrays.DisallowShortArraySyntax.Found">
+		<severity>0</severity>
+	</rule>
+	<rule ref="Generic.Arrays.DisallowLongArraySyntax.Found" />
+
+	<!-- Nesting levels -->
+	<rule ref="Generic.Metrics.NestingLevel">
+		<properties>
+			<property name="absoluteNestingLevel" value="3" />
+		</properties>
+	</rule>
+
+	<exclude-pattern>assets/civicrm/*</exclude-pattern>
+
+	<!--
+	<exclude-pattern>node_modules/*</exclude-pattern>
+	<exclude-pattern>vendor/*</exclude-pattern>
+	-->
+
+</ruleset>

--- a/phpcs.xml
+++ b/phpcs.xml
@@ -28,6 +28,13 @@
 		<exclude name="WordPress.Files.FileName.InvalidClassFileName"/>
 		<exclude name="WordPress.Files.FileName.NotHyphenatedLowercase"/>
 
+		<!-- Remove when error logging has been moved to a function -->
+		<exclude name="WordPress.PHP.DevelopmentFunctions.error_log_error_log"/>
+		<exclude name="PEAR.Functions.FunctionCallSignature.ContentAfterOpenBracket"/>
+		<exclude name="WordPress.PHP.DevelopmentFunctions.error_log_print_r"/>
+		<exclude name="PEAR.Functions.FunctionCallSignature.MultipleArguments"/>
+		<exclude name="PEAR.Functions.FunctionCallSignature.CloseBracketLine"/>
+
 	</rule>
 
 	<rule ref="WordPress.WP.I18n">
@@ -50,10 +57,5 @@
 	</rule>
 
 	<exclude-pattern>assets/civicrm/*</exclude-pattern>
-
-	<!--
-	<exclude-pattern>node_modules/*</exclude-pattern>
-	<exclude-pattern>vendor/*</exclude-pattern>
-	-->
 
 </ruleset>

--- a/wpcv-woo-civi-integration.php
+++ b/wpcv-woo-civi-integration.php
@@ -377,7 +377,11 @@ class WPCV_Woo_Civi {
 		// Init Product objects.
 		$this->products = new WPCV_Woo_Civi_Products();
 		$this->products_variable = new WPCV_Woo_Civi_Products_Variable();
-		$this->products_custom = new WPCV_Woo_Civi_Products_Custom();
+
+		// Maybe init Custom Products object.
+		if ( defined( 'WPCV_WOO_CIVI_PRODUCTS_CUSTOM' ) && WPCV_WOO_CIVI_PRODUCTS_CUSTOM ) {
+			$this->products_custom = new WPCV_Woo_Civi_Products_Custom();
+		}
 
 		// Init CiviCRM Component objects.
 		$this->campaign = new WPCV_Woo_Civi_Campaign();

--- a/wpcv-woo-civi-integration.php
+++ b/wpcv-woo-civi-integration.php
@@ -11,6 +11,8 @@
  * Text Domain: wpcv-woo-civi-integration
  * Domain Path: /languages
  * Depends: CiviCRM
+ *
+ * @package WPCV_Woo_Civi
  */
 
 // Exit if accessed directly.
@@ -538,7 +540,7 @@ class WPCV_Woo_Civi {
 	 *
 	 * @since 2.0
 	 *
-	 * @param array $links The list of plugin links.
+	 * @param array  $links The list of plugin links.
 	 * @param string $file The plugin file.
 	 * @return string $links The modified list of plugin links.
 	 */
@@ -667,7 +669,8 @@ class WPCV_Woo_Civi {
 		$back = sprintf(
 			/* translators: %1$s: The opening anchor tag, %2$s: The closing anchor tag */
 			__( 'Back to the WordPress %1$splugins page%2$s.', 'wpcv-woo-civi-integration' ),
-			'<a href="' . esc_url( get_admin_url( null, 'plugins.php' ) ) . '">', '</a>'
+			'<a href="' . esc_url( get_admin_url( null, 'plugins.php' ) ) . '">',
+			'</a>'
 		);
 
 		$message = '<h1>' . $heading . '</h1>';
@@ -707,7 +710,8 @@ class WPCV_Woo_Civi {
 		$back = sprintf(
 			/* translators: %1$s: The opening anchor tag, %2$s: The closing anchor tag */
 			__( 'Back to the WordPress %1$splugins page%2$s.', 'wpcv-woo-civi-integration' ),
-			'<a href="' . esc_url( get_admin_url( null, 'plugins.php' ) ) . '">', '</a>'
+			'<a href="' . esc_url( get_admin_url( null, 'plugins.php' ) ) . '">',
+			'</a>'
 		);
 
 		$message = '<h1>' . $heading . '</h1>';
@@ -747,7 +751,8 @@ class WPCV_Woo_Civi {
 		$back = sprintf(
 			/* translators: %1$s: The opening anchor tag, %2$s: The closing anchor tag */
 			__( 'Back to the WordPress %1$splugins page%2$s.', 'wpcv-woo-civi-integration' ),
-			'<a href="' . esc_url( get_admin_url( null, 'plugins.php' ) ) . '">', '</a>'
+			'<a href="' . esc_url( get_admin_url( null, 'plugins.php' ) ) . '">',
+			'</a>'
 		);
 
 		$message = '<h1>' . $heading . '</h1>';


### PR DESCRIPTION
Use of the experimental Custom Product Types supplied by this plugin now requires defining the `WPCV_WOO_CIVI_PRODUCTS_CUSTOM` constant. Existing Products should revert to the built-in WooCommerce "Simple" Product Type.