### PR TITLE
Product variation migration

### DIFF
--- a/wpcv-woo-civi-integration.php
+++ b/wpcv-woo-civi-integration.php
@@ -308,13 +308,6 @@ class WPCV_Woo_Civi {
 	 */
 	private function migrate() {
 
-		function debug_to_console($data) {
-			$output = $data;
-			if (is_array($output))
-				$output = implode(',', $output);
-		
-			echo "<script>console.log('Debug Objects: " . $output . "' );</script>";
-		}
 		// Include Contribution class and init.
 		include WPCV_WOO_CIVI_PATH . 'includes/classes/class-woo-civi-contribution.php';
 		$this->contribution = new WPCV_Woo_Civi_Contribution();
@@ -322,7 +315,7 @@ class WPCV_Woo_Civi {
 		// Include Admin Migrate class and init.
 		include WPCV_WOO_CIVI_PATH . 'includes/classes/class-woo-civi-admin-migrate.php';
 		$this->migrate = new WPCV_Woo_Civi_Admin_Migrate();
-		
+
 	}
 
 	/**

--- a/wpcv-woo-civi-integration.php
+++ b/wpcv-woo-civi-integration.php
@@ -308,6 +308,13 @@ class WPCV_Woo_Civi {
 	 */
 	private function migrate() {
 
+		function debug_to_console($data) {
+			$output = $data;
+			if (is_array($output))
+				$output = implode(',', $output);
+		
+			echo "<script>console.log('Debug Objects: " . $output . "' );</script>";
+		}
 		// Include Contribution class and init.
 		include WPCV_WOO_CIVI_PATH . 'includes/classes/class-woo-civi-contribution.php';
 		$this->contribution = new WPCV_Woo_Civi_Contribution();
@@ -315,7 +322,7 @@ class WPCV_Woo_Civi {
 		// Include Admin Migrate class and init.
 		include WPCV_WOO_CIVI_PATH . 'includes/classes/class-woo-civi-admin-migrate.php';
 		$this->migrate = new WPCV_Woo_Civi_Admin_Migrate();
-
+		
 	}
 
 	/**


### PR DESCRIPTION
Added in a feature that migrates the CiviCRM financial and membership types for product variations. 

- Products with a membership type will have the entity type set as membership, even if a financial type is defined. Financial type will also default as donation if no financial type is set before the migration. 
- Products with a financial type set and no membership type will have the financial type entity. 