### PR TITLE
Declare incompatibility with WooCommerce HPOS

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 **Donate link:** https://www.paypal.me/interactivist<br/>
 **Tags:** civicrm, woocommerce, contribution, sync<br/>
 **Requires at least:** 5.7<br/>
-**Tested up to:** 5.8<br/>
+**Tested up to:** 6.1<br/>
 **Stable tag:** 3.0<br/>
 **License:** GPLv3<br/>
 **License URI:** https://www.gnu.org/licenses/gpl-3.0.html

--- a/readme.txt
+++ b/readme.txt
@@ -3,7 +3,7 @@ Contributors: needle, bastho, mecachisenros, rajeshrhino, kcristiano, tadpolecc
 Tags: civicrm, woocommerce, integration
 Requires PHP: 7.1
 Requires at least: 5.7
-Tested up to: 5.8
+Tested up to: 6.1
 Stable tag: 3.0
 License: GPLv3
 License URI: https://www.gnu.org/licenses/gpl-3.0.html

--- a/wpcv-woo-civi-integration.php
+++ b/wpcv-woo-civi-integration.php
@@ -410,16 +410,8 @@ class WPCV_Woo_Civi {
 		// Add settings link to plugin listing page.
 		add_filter( 'plugin_action_links', [ $this, 'add_action_links' ], 10, 2 );
 
-		/*
-		 * Declare incompatibility with WooCommerce HPOS.
-		 *
-		 * @see https://github.com/woocommerce/woocommerce/wiki/High-Performance-Order-Storage-Upgrade-Recipe-Book
-		 */
-		add_action( 'before_woocommerce_init', function() {
-			if ( class_exists( \Automattic\WooCommerce\Utilities\FeaturesUtil::class ) ) {
-				\Automattic\WooCommerce\Utilities\FeaturesUtil::declare_compatibility( 'custom_order_tables', __FILE__, false );
-			}
-		} );
+		// Declare status of compatibility with WooCommerce HPOS.
+		add_action( 'before_woocommerce_init', [ $this, 'declare_woocommerce_hpos_status' ] );
 
 	}
 
@@ -673,6 +665,25 @@ class WPCV_Woo_Civi {
 		// We're good to go.
 		$this->okay_to_load = true;
 		return true;
+
+	}
+
+	/**
+	 * Declare status of compatibility with WooCommerce HPOS.
+	 *
+	 * @see https://github.com/woocommerce/woocommerce/wiki/High-Performance-Order-Storage-Upgrade-Recipe-Book
+	 *
+	 * @since 3.0
+	 */
+	public function declare_woocommerce_hpos_status() {
+
+		// Bail if we can't declare compatibility.
+		if ( ! class_exists( \Automattic\WooCommerce\Utilities\FeaturesUtil::class ) ) {
+			return;
+		}
+
+		// When this plugin is compatible, switch to final param to "true".
+		\Automattic\WooCommerce\Utilities\FeaturesUtil::declare_compatibility( 'custom_order_tables', __FILE__, false );
 
 	}
 

--- a/wpcv-woo-civi-integration.php
+++ b/wpcv-woo-civi-integration.php
@@ -364,7 +364,7 @@ class WPCV_Woo_Civi {
 	 *
 	 * @since 2.0
 	 */
-	public function setup_objects() {
+	private function setup_objects() {
 
 		// Init Admin object.
 		$this->admin = new WPCV_Woo_Civi_Admin();

--- a/wpcv-woo-civi-integration.php
+++ b/wpcv-woo-civi-integration.php
@@ -410,6 +410,17 @@ class WPCV_Woo_Civi {
 		// Add settings link to plugin listing page.
 		add_filter( 'plugin_action_links', [ $this, 'add_action_links' ], 10, 2 );
 
+		/*
+		 * Declare incompatibility with WooCommerce HPOS.
+		 *
+		 * @see https://github.com/woocommerce/woocommerce/wiki/High-Performance-Order-Storage-Upgrade-Recipe-Book
+		 */
+		add_action( 'before_woocommerce_init', function() {
+			if ( class_exists( \Automattic\WooCommerce\Utilities\FeaturesUtil::class ) ) {
+				\Automattic\WooCommerce\Utilities\FeaturesUtil::declare_compatibility( 'custom_order_tables', __FILE__, false );
+			}
+		} );
+
 	}
 
 	/**


### PR DESCRIPTION
This plugin cannot be used with WooCommerce "High-Performance Order Storage" yet.