### PR TITLE
Use API4 for retrieving Dedupe Rule Groups

### DIFF
--- a/includes/classes/class-woo-civi-contact-address.php
+++ b/includes/classes/class-woo-civi-contact-address.php
@@ -370,6 +370,10 @@ class WPCV_Woo_Civi_Contact_Address {
 		// Unhook to prevent any possibility of recursion.
 		remove_action( 'woocommerce_customer_save_address', [ $this, 'sync_woo_to_civicrm' ] );
 
+		// Also unhook CiviCRM's callbacks.
+		remove_action( 'user_register', [ civi_wp()->users, 'update_user' ] );
+		remove_action( 'profile_update', [ civi_wp()->users, 'update_user' ] );
+
 		// Update the Fields for the mapped WooCommerce Address Type.
 		$address_type = array_search( (int) $object_ref->location_type_id, $mapped, true );
 		foreach ( $this->get_field_mappings( $address_type ) as $wc_field => $civi_field ) {
@@ -422,6 +426,10 @@ class WPCV_Woo_Civi_Contact_Address {
 
 		// Rehook callback for WooCommerce action.
 		add_action( 'woocommerce_customer_save_address', [ $this, 'sync_woo_to_civicrm' ], 10, 2 );
+
+		// Rehook CiviCRM's callbacks.
+		add_action( 'user_register', [ civi_wp()->users, 'update_user' ] );
+		add_action( 'profile_update', [ civi_wp()->users, 'update_user' ] );
 
 		// Let's make an array of the data.
 		$args = [

--- a/phpcs.xml
+++ b/phpcs.xml
@@ -67,7 +67,7 @@
 	<!-- Nesting levels -->
 	<rule ref="Generic.Metrics.NestingLevel">
 		<properties>
-			<property name="absoluteNestingLevel" value="4" />
+			<property name="absoluteNestingLevel" value="5" />
 		</properties>
 	</rule>
 


### PR DESCRIPTION
Some critical files in CiviCRM were removed without warning in [this commit](https://github.com/civicrm/civicrm-core/pull/26025/files).