### PR TITLE
Check like with like for Address location types

### DIFF
--- a/includes/classes/class-woo-civi-contact-address.php
+++ b/includes/classes/class-woo-civi-contact-address.php
@@ -193,9 +193,9 @@ class WPCV_Woo_Civi_Contact_Address {
 			// Try and find an existing CiviCRM Address record.
 			foreach ( $existing_addresses as $existing ) {
 				// Does this Address have the desired Location Type?
-				if ( isset( $existing->location_type_id ) && $existing->location_type_id === $location_type_id ) {
+				if ( isset( $existing->location_type_id ) && (int) $existing->location_type_id === $location_type_id ) {
 					// Let's update that one.
-					$address_params['id'] = $existing->id;
+					$address_params['id'] = (int) $existing->id;
 					// Skip if no update needed.
 					if ( $this->is_match( $existing, $address_params ) ) {
 						continue 2;


### PR DESCRIPTION
CiviCRM does not cast Location Type IDs as integers when retrieving Addresses via API3. This caused checks for existing Customer Addresses to fail. Fixed in this PR - possibly fixes #43 as well.