### PR TITLE
Avoid fatal errors when calling API3

### DIFF
--- a/includes/classes/class-woo-civi-campaign.php
+++ b/includes/classes/class-woo-civi-campaign.php
@@ -200,6 +200,7 @@ class WPCV_Woo_Civi_Campaign {
 		}
 
 		$params = [
+			'version' => 3,
 			'sequential' => 1,
 			'is_active' => 1,
 			'status_id' => [ 'NOT IN' => [ 'Completed', 'Cancelled' ] ],
@@ -218,7 +219,7 @@ class WPCV_Woo_Civi_Campaign {
 		 */
 		$params = apply_filters( 'wpcv_woo_civi/campaigns/get/params', $params );
 
-		$result = civicrm_api3( 'Campaign', 'get', $params );
+		$result = civicrm_api( 'Campaign', 'get', $params );
 
 		// Return early if something went wrong.
 		if ( ! empty( $result['error'] ) ) {
@@ -278,6 +279,7 @@ class WPCV_Woo_Civi_Campaign {
 		}
 
 		$params = [
+			'version' => 3,
 			'sequential' => 1,
 			'return' => [ 'id', 'name', 'status_id' ],
 			'options' => [
@@ -295,7 +297,7 @@ class WPCV_Woo_Civi_Campaign {
 		 */
 		$params = apply_filters( 'wpcv_woo_civi/campaigns/get_all/params', $params );
 
-		$result = civicrm_api3( 'Campaign', 'get', $params );
+		$result = civicrm_api( 'Campaign', 'get', $params );
 
 		// Return early if something went wrong.
 		if ( ! empty( $result['error'] ) ) {
@@ -356,6 +358,7 @@ class WPCV_Woo_Civi_Campaign {
 		}
 
 		$params = [
+			'version' => 3,
 			'sequential' => 1,
 			'id' => $campaign_id,
 			'options' => [
@@ -363,7 +366,7 @@ class WPCV_Woo_Civi_Campaign {
 			],
 		];
 
-		$result = civicrm_api3( 'Campaign', 'get', $params );
+		$result = civicrm_api( 'Campaign', 'get', $params );
 
 		// Return early if something went wrong.
 		if ( ! empty( $result['error'] ) ) {
@@ -415,6 +418,7 @@ class WPCV_Woo_Civi_Campaign {
 		}
 
 		$params = [
+			'version' => 3,
 			'sequential' => 1,
 			'name' => $campaign_name,
 			'options' => [
@@ -422,7 +426,7 @@ class WPCV_Woo_Civi_Campaign {
 			],
 		];
 
-		$result = civicrm_api3( 'Campaign', 'get', $params );
+		$result = civicrm_api( 'Campaign', 'get', $params );
 
 		// Return early if something went wrong.
 		if ( ! empty( $result['error'] ) ) {
@@ -482,6 +486,7 @@ class WPCV_Woo_Civi_Campaign {
 		}
 
 		$params = [
+			'version' => 3,
 			'sequential' => 1,
 			'option_group_id' => 'campaign_status',
 			'options' => [
@@ -498,7 +503,7 @@ class WPCV_Woo_Civi_Campaign {
 		 */
 		$params = apply_filters( 'wpcv_woo_civi/campaign_statuses/get/params', $params );
 
-		$result = civicrm_api3( 'OptionValue', 'get', $params );
+		$result = civicrm_api( 'OptionValue', 'get', $params );
 
 		// Return early if something went wrong.
 		if ( ! empty( $result['error'] ) ) {

--- a/includes/classes/class-woo-civi-contact-address.php
+++ b/includes/classes/class-woo-civi-contact-address.php
@@ -589,8 +589,11 @@ class WPCV_Woo_Civi_Contact_Address {
 			return false;
 		}
 
+		// Add API version.
+		$params['version'] = 3;
+
 		// Call the API.
-		$result = civicrm_api3( 'Address', 'create', $params );
+		$result = civicrm_api( 'Address', 'create', $params );
 
 		// Log and bail if there's an error.
 		if ( ! empty( $result['is_error'] ) && 1 === (int) $result['is_error'] ) {
@@ -666,11 +669,12 @@ class WPCV_Woo_Civi_Contact_Address {
 
 		// Construct API query.
 		$params = [
+			'version' => 3,
 			'contact_id' => $contact_id,
 		];
 
 		// Get Address details via API.
-		$result = civicrm_api3( 'Address', 'get', $params );
+		$result = civicrm_api( 'Address', 'get', $params );
 
 		// Bail if there's an error.
 		if ( ! empty( $result['is_error'] ) && 1 === (int) $result['is_error'] ) {
@@ -899,13 +903,14 @@ class WPCV_Woo_Civi_Contact_Address {
 		}
 
 		$params = [
+			'version' => 3,
 			'field' => 'location_type_id',
 			'options' => [
 				'limit' => 0,
 			],
 		];
 
-		$result = civicrm_api3( 'Address', 'getoptions', $params );
+		$result = civicrm_api( 'Address', 'getoptions', $params );
 
 		// Return early if something went wrong.
 		if ( ! empty( $result['error'] ) ) {

--- a/includes/classes/class-woo-civi-contact-email.php
+++ b/includes/classes/class-woo-civi-contact-email.php
@@ -426,8 +426,11 @@ class WPCV_Woo_Civi_Contact_Email {
 			return false;
 		}
 
+		// Add API version.
+		$params['version'] = 3;
+
 		// Call the API.
-		$result = civicrm_api3( 'Email', 'create', $params );
+		$result = civicrm_api( 'Email', 'create', $params );
 
 		// Log and bail if there's an error.
 		if ( ! empty( $result['is_error'] ) && 1 === (int) $result['is_error'] ) {

--- a/includes/classes/class-woo-civi-contact-phone.php
+++ b/includes/classes/class-woo-civi-contact-phone.php
@@ -429,8 +429,11 @@ class WPCV_Woo_Civi_Contact_Phone {
 			return false;
 		}
 
+		// Add API version.
+		$params['version'] = 3;
+
 		// Call the API.
-		$result = civicrm_api3( 'Phone', 'create', $params );
+		$result = civicrm_api( 'Phone', 'create', $params );
 
 		// Log and bail if there's an error.
 		if ( ! empty( $result['is_error'] ) && 1 === (int) $result['is_error'] ) {

--- a/includes/classes/class-woo-civi-contact.php
+++ b/includes/classes/class-woo-civi-contact.php
@@ -377,11 +377,12 @@ class WPCV_Woo_Civi_Contact {
 		}
 
 		$params = [
+			'version' => 3,
 			'sequential' => 1,
 			'email' => $email,
 		];
 
-		$result = civicrm_api3( 'Contact', 'get', $params );
+		$result = civicrm_api( 'Contact', 'get', $params );
 
 		// If there's an error.
 		if ( ! empty( $result['is_error'] ) ) {
@@ -601,11 +602,12 @@ class WPCV_Woo_Civi_Contact {
 		}
 
 		$params = [
+			'version' => 3,
 			'sequential' => 1,
 			$property => $id,
 		];
 
-		$result = civicrm_api3( 'UFMatch', 'get', $params );
+		$result = civicrm_api( 'UFMatch', 'get', $params );
 
 		// Bail if there's an error.
 		if ( ! empty( $result['is_error'] ) && 1 === (int) $result['is_error'] ) {
@@ -660,6 +662,7 @@ class WPCV_Woo_Civi_Contact {
 
 		// Maybe debug?
 		$params = [
+			'version' => 3,
 			'debug' => 1,
 		] + $contact;
 

--- a/includes/classes/class-woo-civi-contribution.php
+++ b/includes/classes/class-woo-civi-contribution.php
@@ -340,6 +340,7 @@ class WPCV_Woo_Civi_Contribution {
 
 		// Maybe debug?
 		$params = [
+			'version' => 3,
 			'debug' => 1,
 		] + $contribution;
 
@@ -357,7 +358,7 @@ class WPCV_Woo_Civi_Contribution {
 		 *
 		 * $params['id'] = 255;
 		 */
-		$result = civicrm_api3( 'Contribution', 'create', $params );
+		$result = civicrm_api( 'Contribution', 'create', $params );
 
 		// Sanity check.
 		if ( ! empty( $result['error'] ) ) {

--- a/includes/classes/class-woo-civi-helper.php
+++ b/includes/classes/class-woo-civi-helper.php
@@ -202,6 +202,7 @@ class WPCV_Woo_Civi_Helper {
 		}
 
 		$params = [
+			'version' => 3,
 			'sequential' => 1,
 			'is_active' => 1,
 			'options' => [
@@ -218,7 +219,7 @@ class WPCV_Woo_Civi_Helper {
 		 */
 		$params = apply_filters( 'wpcv_woo_civi/financial_types/get/params', $params );
 
-		$result = civicrm_api3( 'FinancialType', 'get', $params );
+		$result = civicrm_api( 'FinancialType', 'get', $params );
 
 		// Return early if something went wrong.
 		if ( ! empty( $result['error'] ) ) {

--- a/includes/classes/class-woo-civi-membership.php
+++ b/includes/classes/class-woo-civi-membership.php
@@ -290,6 +290,7 @@ class WPCV_Woo_Civi_Membership {
 		}
 
 		$params = [
+			'version' => 3,
 			'sequential' => 1,
 			'is_active' => 1,
 			'options' => [
@@ -306,7 +307,7 @@ class WPCV_Woo_Civi_Membership {
 		 */
 		$params = apply_filters( 'wpcv_woo_civi/membership_types/get/params', $params );
 
-		$result = civicrm_api3( 'MembershipType', 'get', $params );
+		$result = civicrm_api( 'MembershipType', 'get', $params );
 
 		// Return early if something went wrong.
 		if ( ! empty( $result['error'] ) ) {

--- a/includes/classes/class-woo-civi-settings-states.php
+++ b/includes/classes/class-woo-civi-settings-states.php
@@ -124,13 +124,14 @@ class WPCV_Woo_Civi_Settings_States {
 		}
 
 		$params = [
+			'version' => 3,
 			'sequential' => 1,
 			'options' => [
 				'limit' => 0,
 			],
 		];
 
-		$result = civicrm_api3( 'Country', 'get', $params );
+		$result = civicrm_api( 'Country', 'get', $params );
 
 		// Return early if something went wrong.
 		if ( ! empty( $result['error'] ) ) {
@@ -166,11 +167,12 @@ class WPCV_Woo_Civi_Settings_States {
 		}
 
 		$params = [
+			'version' => 3,
 			'sequential' => 1,
 			'iso_code' => $woo_country,
 		];
 
-		$result = civicrm_api3( 'Country', 'getsingle', $params );
+		$result = civicrm_api( 'Country', 'getsingle', $params );
 
 		// Bail if something went wrong.
 		if ( ! empty( $result['error'] ) ) {
@@ -214,11 +216,12 @@ class WPCV_Woo_Civi_Settings_States {
 		}
 
 		$params = [
+			'version' => 3,
 			'sequential' => 1,
 			'id' => $country_id,
 		];
 
-		$result = civicrm_api3( 'Country', 'getsingle', $params );
+		$result = civicrm_api( 'Country', 'getsingle', $params );
 
 		// Bail if something went wrong.
 		if ( ! empty( $result['error'] ) ) {

--- a/includes/classes/class-woo-civi-tax.php
+++ b/includes/classes/class-woo-civi-tax.php
@@ -211,6 +211,7 @@ class WPCV_Woo_Civi_Tax {
 		}
 
 		$params = [
+			'version' => 3,
 			'return' => [
 				'id',
 				'entity_table',
@@ -228,7 +229,7 @@ class WPCV_Woo_Civi_Tax {
 		];
 
 		// Call the CiviCRM API.
-		$result = civicrm_api3( 'EntityFinancialAccount', 'get', $params );
+		$result = civicrm_api( 'EntityFinancialAccount', 'get', $params );
 
 		// Return early if something went wrong.
 		if ( ! empty( $result['error'] ) ) {


### PR DESCRIPTION
Calling `civicrm_api3()` outside of `try/catch` block throws a fatal error. Calling `civicrm_api()` with the `'version'=> 3` param set does not - and therefore allows code execution to continue. PR fixes these situations until migration to API4 calls is made.