### PR TITLE
Catch more generic Exception object

### DIFF
--- a/includes/classes/class-woo-civi-contact-orders-tab.php
+++ b/includes/classes/class-woo-civi-contact-orders-tab.php
@@ -179,7 +179,7 @@ class WPCV_Woo_Civi_Contact_Orders_Tab {
 
 				$contact = civicrm_api3( 'Contact', 'getsingle', $params );
 
-			} catch ( CiviCRM_API3_Exception $e ) {
+			} catch ( Exception $e ) {
 
 				// Write to CiviCRM log.
 				CRM_Core_Error::debug_log_message( __( 'Unable to find Contact', 'wpcv-woo-civi-integration' ) );

--- a/includes/classes/class-woo-civi-contribution.php
+++ b/includes/classes/class-woo-civi-contribution.php
@@ -441,7 +441,7 @@ class WPCV_Woo_Civi_Contribution {
 
 			$result = civicrm_api3( 'Order', 'create', $params );
 
-		} catch ( CiviCRM_API3_Exception $e ) {
+		} catch ( Exception $e ) {
 
 			// Write to CiviCRM log and continue.
 			CRM_Core_Error::debug_log_message( __( 'Unable to create an Order via the CiviCRM Order API', 'wpcv-woo-civi-integration' ) );
@@ -735,7 +735,7 @@ class WPCV_Woo_Civi_Contribution {
 
 			$result = civicrm_api3( 'Payment', 'create', $params );
 
-		} catch ( CiviCRM_API3_Exception $e ) {
+		} catch ( Exception $e ) {
 
 			// Write to CiviCRM log.
 			CRM_Core_Error::debug_log_message( __( 'Unable to create Payment record.', 'wpcv-woo-civi-integration' ) );
@@ -855,7 +855,7 @@ class WPCV_Woo_Civi_Contribution {
 
 			$result = civicrm_api3( 'Note', 'create', $params );
 
-		} catch ( CiviCRM_API3_Exception $e ) {
+		} catch ( Exception $e ) {
 
 			// Write to CiviCRM log.
 			CRM_Core_Error::debug_log_message( __( 'Unable to create a Note for a Contribution.', 'wpcv-woo-civi-integration' ) );

--- a/includes/classes/class-woo-civi-helper.php
+++ b/includes/classes/class-woo-civi-helper.php
@@ -88,7 +88,7 @@ class WPCV_Woo_Civi_Helper {
 
 			$setting = civicrm_api3( 'Setting', 'getvalue', $params );
 
-		} catch ( CiviCRM_API3_Exception $e ) {
+		} catch ( Exception $e ) {
 
 			/* translators: %s: The name of the requested CiviCRM Setting */
 			$human_readable = sprintf( __( 'Unable to fetch the "%s" setting.', 'wpcv-woo-civi-integration' ), $name );
@@ -300,7 +300,7 @@ class WPCV_Woo_Civi_Helper {
 
 			$result = civicrm_api3( 'PriceSet', 'get', $params );
 
-		} catch ( CiviCRM_API3_Exception $e ) {
+		} catch ( Exception $e ) {
 
 			// Write to CiviCRM log.
 			CRM_Core_Error::debug_log_message( __( 'Unable to fetch Price Sets', 'wpcv-woo-civi-integration' ) );
@@ -359,7 +359,7 @@ class WPCV_Woo_Civi_Helper {
 
 			$result = civicrm_api3( 'PriceFieldValue', 'get', $params );
 
-		} catch ( CiviCRM_API3_Exception $e ) {
+		} catch ( Exception $e ) {
 
 			// Write to CiviCRM log.
 			CRM_Core_Error::debug_log_message( __( 'Unable to fetch Price Field Values', 'wpcv-woo-civi-integration' ) );
@@ -654,7 +654,7 @@ class WPCV_Woo_Civi_Helper {
 
 			$result = civicrm_api3( 'Setting', 'getvalue', $params );
 
-		} catch ( CiviCRM_API3_Exception $e ) {
+		} catch ( Exception $e ) {
 
 			// Write to CiviCRM log.
 			CRM_Core_Error::debug_log_message( __( 'Unable to fetch Decimal Separator', 'wpcv-woo-civi-integration' ) );
@@ -712,7 +712,7 @@ class WPCV_Woo_Civi_Helper {
 
 			$result = civicrm_api3( 'Setting', 'getvalue', $params );
 
-		} catch ( CiviCRM_API3_Exception $e ) {
+		} catch ( Exception $e ) {
 
 			// Write to CiviCRM log.
 			CRM_Core_Error::debug_log_message( __( 'Unable to fetch Thousand Separator', 'wpcv-woo-civi-integration' ) );

--- a/includes/classes/class-woo-civi-membership.php
+++ b/includes/classes/class-woo-civi-membership.php
@@ -372,7 +372,7 @@ class WPCV_Woo_Civi_Membership {
 
 			$result = civicrm_api3( 'MembershipType', 'get', $params );
 
-		} catch ( CiviCRM_API3_Exception $e ) {
+		} catch ( Exception $e ) {
 
 			// Write to CiviCRM log.
 			CRM_Core_Error::debug_log_message( __( 'Unable to retrieve CiviCRM Membership Types.', 'wpcv-woo-civi-integration' ) );
@@ -434,7 +434,7 @@ class WPCV_Woo_Civi_Membership {
 
 			return $result;
 
-		} catch ( CiviCRM_API3_Exception $e ) {
+		} catch ( Exception $e ) {
 
 			// Write to CiviCRM log.
 			CRM_Core_Error::debug_log_message( __( 'Unable to retrieve CiviCRM Membership Type.', 'wpcv-woo-civi-integration' ) );
@@ -486,7 +486,7 @@ class WPCV_Woo_Civi_Membership {
 
 			$result = civicrm_api3( 'PriceField', 'get', $params );
 
-		} catch ( CiviCRM_API3_Exception $e ) {
+		} catch ( Exception $e ) {
 
 			// Write to CiviCRM log.
 			CRM_Core_Error::debug_log_message( __( 'Unable to retrieve default Membership Price Field ID', 'wpcv-woo-civi-integration' ) );

--- a/includes/classes/class-woo-civi-participant.php
+++ b/includes/classes/class-woo-civi-participant.php
@@ -658,7 +658,7 @@ class WPCV_Woo_Civi_Participant {
 
 			$option_group = civicrm_api( 'OptionGroup', 'getsingle', $params );
 
-		} catch ( CiviCRM_API3_Exception $e ) {
+		} catch ( Exception $e ) {
 
 			// Write to CiviCRM log.
 			CRM_Core_Error::debug_log_message( __( 'Unable to retrieve CiviCRM Participant Role Option Group.', 'wpcv-woo-civi-integration' ) );

--- a/includes/classes/class-woo-civi-products.php
+++ b/includes/classes/class-woo-civi-products.php
@@ -568,7 +568,7 @@ class WPCV_Woo_Civi_Products {
 
 			$result = civicrm_api3( 'PriceField', 'get', $params );
 
-		} catch ( CiviCRM_API3_Exception $e ) {
+		} catch ( Exception $e ) {
 
 			// Write to CiviCRM log.
 			CRM_Core_Error::debug_log_message( __( 'Unable to retrieve default Contribution Price Field ID', 'wpcv-woo-civi-integration' ) );


### PR DESCRIPTION
CiviCRM switched from `API_Exception` and `CiviCRM_API3_Exception` to `CRM_Core_Exception` in 5.52. Our `catch()` blocks need to accommodate both, so switch to catching a more generic Exception object.