### PR TITLE
Removes Custom Product reference when not enabled

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 **Donate link:** https://www.paypal.me/interactivist<br/>
 **Tags:** civicrm, woocommerce, contribution, sync<br/>
 **Requires at least:** 5.7<br/>
-**Tested up to:** 6.9<br/>
+**Tested up to:** 7.0<br/>
 **Stable tag:** 3.1.4a<br/>
 **License:** GPLv2 or later<br/>
 **License URI:** https://www.gnu.org/licenses/old-licenses/gpl-2.0.html

--- a/includes/classes/class-woo-civi-admin.php
+++ b/includes/classes/class-woo-civi-admin.php
@@ -453,7 +453,7 @@ class WPCV_Woo_Civi_Admin {
 
 		// Assume there is no Custom Contribution Product Type.
 		$metabox['args']['custom_product_type_exists'] = false;
-		if ( WPCV_WCI()->contribution->active ) {
+		if ( false !== WPCV_WCI()->products_custom && WPCV_WCI()->contribution->active ) {
 			$metabox['args']['custom_product_type_exists'] = true;
 		}
 
@@ -484,7 +484,7 @@ class WPCV_Woo_Civi_Admin {
 
 		// Assume there is no Custom Membership Product Type.
 		$metabox['args']['custom_product_type_exists'] = false;
-		if ( WPCV_WCI()->membership->active ) {
+		if ( false !== WPCV_WCI()->products_custom && WPCV_WCI()->membership->active ) {
 			$metabox['args']['custom_product_type_exists'] = true;
 		}
 
@@ -518,7 +518,7 @@ class WPCV_Woo_Civi_Admin {
 
 		// Assume there is no Custom Participant Product Type.
 		$metabox['args']['custom_product_type_exists'] = false;
-		if ( WPCV_WCI()->participant->active ) {
+		if ( false !== WPCV_WCI()->products_custom && WPCV_WCI()->participant->active ) {
 			$metabox['args']['custom_product_type_exists'] = true;
 		}
 

--- a/readme.txt
+++ b/readme.txt
@@ -3,7 +3,7 @@ Contributors: needle, bastho, mecachisenros, rajeshrhino, kcristiano, tadpolecc
 Donate link: https://www.paypal.me/interactivist
 Tags: civicrm, woocommerce, integration
 Requires at least: 5.7
-Tested up to: 6.9
+Tested up to: 7.0
 Stable tag: 3.1.4a
 Requires PHP: 7.4
 License: GPLv2 or later

--- a/wpcv-woo-civi-integration.php
+++ b/wpcv-woo-civi-integration.php
@@ -173,11 +173,13 @@ class WPCV_Woo_Civi {
 	/**
 	 * WooCommerce Custom Products object.
 	 *
+	 * Initialised as false for easier "enabled" testing.
+	 *
 	 * @since 2.2
 	 * @access public
 	 * @var WPCV_Woo_Civi_Products_Custom
 	 */
-	public $products_custom;
+	public $products_custom = false;
 
 	/**
 	 * WooCommerce Variable Products object.


### PR DESCRIPTION
Also bumps WordPress tested-to version